### PR TITLE
fix(define-prop): transform correct call expression

### DIFF
--- a/.changeset/rich-cobras-marry.md
+++ b/.changeset/rich-cobras-marry.md
@@ -1,0 +1,5 @@
+---
+"@vue-macros/define-prop": patch
+---
+
+fix(define-prop): transform correct call expression

--- a/packages/define-prop/src/core/index.ts
+++ b/packages/define-prop/src/core/index.ts
@@ -46,7 +46,8 @@ export async function transformDefineProp(
   await walkASTSetup(setupAst, (setup) => {
     setup.onEnter(
       (node, parent): node is t.CallExpression =>
-        !isCallOf(parent, '$') && isCallOf(node, ['$', DEFINE_PROP]),
+        (isCallOf(node, '$') && isCallOf(node.arguments[0], DEFINE_PROP)) ||
+        (!isCallOf(parent, '$') && isCallOf(node, DEFINE_PROP)),
       (node, parent) => {
         const propName = walkCall(
           isCallOf(node, '$') && isCallOf(node.arguments[0], DEFINE_PROP)

--- a/playground/vue3/src/examples/define-prop/child.vue
+++ b/playground/vue3/src/examples/define-prop/child.vue
@@ -3,13 +3,13 @@ import { Assert } from '../../assert'
 const foo = defineProp<string>('foo')
 const bar = $(defineProp<string>())
 
-definePropsRefs(['msg'])
+const props = $(definePropsRefs(['msg']))
 </script>
 
 <template>
   <div>foo: {{ foo }}</div>
   <div>
     <Assert :l="bar" r="bar" />
-    <Assert :l="'msg' in $props" :r="true" />
+    <Assert :l="'msg' in props" :r="true" />
   </div>
 </template>


### PR DESCRIPTION
closed #479

``` ts
const props = $(definePropsRefs(['msg'])) 
```

![image](https://github.com/vue-macros/vue-macros/assets/32807958/acf9cac8-27e9-4f90-8ba9-6760deb4d4f5)
