### PR TITLE
fix(volar/define-slots): regular expression error

### DIFF
--- a/.changeset/healthy-ways-wave.md
+++ b/.changeset/healthy-ways-wave.md
@@ -1,0 +1,5 @@
+---
+"@vue-macros/volar": patch
+---
+
+fix(volar/define-slots): regular expression error

--- a/packages/volar/src/define-slots.ts
+++ b/packages/volar/src/define-slots.ts
@@ -28,7 +28,7 @@ const transform = ({
 
   replace(
     embeddedFile.content,
-    /var __VLS_slots!: .*/,
+    /var __VLS_slots!: [\S\s]*?;/,
     'var __VLS_slots!: __VLS_DefineSlots<',
     (): Segment<FileRangeCapabilities> => [
       // slots type
@@ -37,7 +37,7 @@ const transform = ({
       typeArg!.pos,
       FileRangeCapabilities.full,
     ],
-    '>'
+    '>;'
   )
   embeddedFile.content.push(
     `type __VLS_DefineSlots<T> = { [SlotName in keyof T]: T[SlotName] extends Function ? T[SlotName] : (_: T[SlotName]) => any }`


### PR DESCRIPTION
### Before
> /var __VLS_slots!: .*/
<img width="468" alt="image" src="https://github.com/vue-macros/vue-macros/assets/32807958/340c2df4-b6d0-43bb-8c8c-f4f383929b4e">

### After
> /var __VLS_slots!: [\S\s]*?;/
<img width="477" alt="image" src="https://github.com/vue-macros/vue-macros/assets/32807958/d7bd3f47-ca33-432a-b56e-413077b8c9b7">

