### PR TITLE
feat(volar): introduce `setupJsdoc`

### DIFF
--- a/.changeset/short-pens-study.md
+++ b/.changeset/short-pens-study.md
@@ -1,0 +1,5 @@
+---
+'@vue-macros/volar': minor
+---
+
+Introduce `setupJsDoc` volar plugin

--- a/.changeset/short-pens-study.md
+++ b/.changeset/short-pens-study.md
@@ -2,4 +2,4 @@
 '@vue-macros/volar': minor
 ---
 
-Introduce `setupJsDoc` volar plugin
+Introduce `setupJsdoc` volar plugin

--- a/docs/guide/bundler-integration.md
+++ b/docs/guide/bundler-integration.md
@@ -141,7 +141,8 @@ npm i -D @vue-macros/volar
       "@vue-macros/volar/define-props-refs",
       "@vue-macros/volar/short-vmodel",
       "@vue-macros/volar/define-slots",
-      "@vue-macros/volar/jsx-directive"
+      "@vue-macros/volar/jsx-directive",
+      "@vue-macros/volar/setup-jsdoc"
 
       // Choose only one of the following
       // "@vue-macros/volar/export-expose",

--- a/docs/zh-CN/guide/bundler-integration.md
+++ b/docs/zh-CN/guide/bundler-integration.md
@@ -141,7 +141,8 @@ npm i -D @vue-macros/volar
       "@vue-macros/volar/define-props-refs",
       "@vue-macros/volar/short-vmodel",
       "@vue-macros/volar/define-slots",
-      "@vue-macros/volar/jsx-directive"
+      "@vue-macros/volar/jsx-directive",
+      "@vue-macros/volar/setup-jsdoc"
 
       // 选择以下其中一个
       // "@vue-macros/volar/export-expose",

--- a/packages/volar/src/setup-jsdoc.ts
+++ b/packages/volar/src/setup-jsdoc.ts
@@ -5,23 +5,20 @@ import {
   type VueLanguagePlugin,
   replace,
 } from '@vue/language-core'
+import type ts from 'typescript'
+
+type HasJSDoc = ts.HasJSDoc & { jsDoc: ts.JSDoc[] }
 
 /**
  * Copy from https://github.com/microsoft/TypeScript/blob/5a97ce8281e2b4dce298c280b0e67ce049681d01/src/compiler/utilitiesPublic.ts#L2515
  *
  * GH#19856 Would like to return `node is Node & { jsDoc: JSDoc[] }` but it causes long compile times
  */
-function hasJSDocNodes(
-  node: import('typescript/lib/tsserverlibrary').Node
-): node is import('typescript/lib/tsserverlibrary').HasJSDoc & {
-  jsDoc: import('typescript/lib/tsserverlibrary').JSDoc[]
-} {
+function hasJSDocNodes(node: ts.Node): node is HasJSDoc {
   if (!node) return false
-
-  const { jsDoc } =
-    node as import('typescript/lib/tsserverlibrary').JSDocContainer & {
-      jsDoc: import('typescript/lib/tsserverlibrary').JSDoc[]
-    }
+  const { jsDoc } = node as ts.Node & {
+    jsDoc: ts.JSDoc[]
+  }
   return !!jsDoc && jsDoc.length > 0
 }
 

--- a/packages/volar/src/setup-jsdoc.ts
+++ b/packages/volar/src/setup-jsdoc.ts
@@ -1,0 +1,78 @@
+import { FileKind } from '@volar/language-core'
+import {
+  type Sfc,
+  type VueEmbeddedFile,
+  type VueLanguagePlugin,
+  replace,
+} from '@vue/language-core'
+
+/**
+ * Copy from https://github.com/microsoft/TypeScript/blob/5a97ce8281e2b4dce298c280b0e67ce049681d01/src/compiler/utilitiesPublic.ts#L2515
+ *
+ * GH#19856 Would like to return `node is Node & { jsDoc: JSDoc[] }` but it causes long compile times
+ */
+function hasJSDocNodes(
+  node: import('typescript/lib/tsserverlibrary').Node
+): node is import('typescript/lib/tsserverlibrary').HasJSDoc & {
+  jsDoc: import('typescript/lib/tsserverlibrary').JSDoc[]
+} {
+  if (!node) return false
+
+  const { jsDoc } =
+    node as import('typescript/lib/tsserverlibrary').JSDocContainer & {
+      jsDoc: import('typescript/lib/tsserverlibrary').JSDoc[]
+    }
+  return !!jsDoc && jsDoc.length > 0
+}
+
+function transform({
+  file,
+  sfc,
+  ts,
+}: {
+  file: VueEmbeddedFile
+  sfc: Sfc
+  ts: typeof import('typescript/lib/tsserverlibrary')
+}) {
+  let jsDoc
+  if (hasJSDocNodes(sfc.scriptSetupAst!.statements[0])) {
+    jsDoc = sfc.scriptSetupAst!.statements[0].jsDoc.at(-1)
+  }
+
+  // With exportRender plugin.
+  for (const stmt of sfc.scriptSetupAst!.statements) {
+    if (!ts.isExportAssignment(stmt)) continue
+
+    if (hasJSDocNodes(stmt)) jsDoc ??= stmt.jsDoc.at(-1)
+  }
+
+  if (jsDoc) {
+    replace(
+      file.content,
+      /(?=export\sdefault)/,
+      `${sfc.scriptSetup?.content.slice(jsDoc.pos, jsDoc.end)}\n`
+    )
+  }
+}
+
+const plugin: VueLanguagePlugin = ({ modules: { typescript: ts } }) => {
+  return {
+    name: 'vue-macros-setup-jsdoc',
+    version: 1,
+    resolveEmbeddedFile(fileName, sfc, embeddedFile) {
+      if (
+        embeddedFile.kind !== FileKind.TypeScriptHostFile ||
+        !sfc.scriptSetup ||
+        !sfc.scriptSetupAst
+      )
+        return
+
+      transform({
+        file: embeddedFile,
+        sfc,
+        ts,
+      })
+    },
+  }
+}
+export default plugin

--- a/playground/vue3/src/examples/setup-jsdoc/button.vue
+++ b/playground/vue3/src/examples/setup-jsdoc/button.vue
@@ -1,0 +1,14 @@
+<script setup lang="tsx">
+/**
+ * # My Button Component
+ * To trigger an operation.
+ *
+ * @deprecated Please use `MyButtonV2` instead.
+ *
+ * @example
+ * ```vue
+ * <MyButton>Click Me</MyButton>
+ * ```
+ */
+defineRender(() => <button />)
+</script>

--- a/playground/vue3/src/examples/setup-jsdoc/export-render/index.vue
+++ b/playground/vue3/src/examples/setup-jsdoc/export-render/index.vue
@@ -1,0 +1,16 @@
+<script setup lang="tsx">
+import { Ok } from '../../../assert'
+
+/**
+ * # ExportRender
+ * Transform `default export` to defineRender.
+ *
+ * @deprecated Please use `ExportRenderV2` instead.
+ *
+ * @example
+ * ```vue
+ * <ExportRender />
+ * ```
+ */
+export default () => <Ok />
+</script>

--- a/playground/vue3/src/examples/setup-jsdoc/index.vue
+++ b/playground/vue3/src/examples/setup-jsdoc/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="tsx">
+import Button from './button.vue'
+import ExportRender from './export-render/index.vue'
+
+defineRender(() => (
+  <>
+    <Button />
+    <ExportRender />
+  </>
+))
+</script>

--- a/playground/vue3/tsconfig.json
+++ b/playground/vue3/tsconfig.json
@@ -28,7 +28,8 @@
       "@vue-macros/volar/export-render",
       "@vue-macros/volar/export-expose",
       "@vue-macros/volar/export-props",
-      "@vue-macros/volar/jsx-directive"
+      "@vue-macros/volar/jsx-directive",
+      "@vue-macros/volar/setup-jsdoc"
     ],
     "experimentalDefinePropProposal": "kevinEdition",
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

With this plugin, you can write jsDoc in front of the first line or 'export default' in <script setup>.

#### Volar Configuration
``` ts
// tsconfig.json
{
 "vueCompilerOptions": {
    "plugins": [
      "@vue-macros/volar/setup-jsdoc"
    ],
  }
}
```
#### Basic Usage
``` vue
<script setup lang="tsx">
/**
 * # My Button Component
 * To trigger an operation.
 *
 * @deprecated Please use `MyButtonV2` instead.
 *
 * @example
 * ```vue
 * <MyButton>Click Me</MyButton>
 * ```
 */
defineRender(() => <button />)
</script>
```
Or before of `export default`
``` vue
<script setup lang="tsx">
import { Ok } from '../../../assert'

/**
 * # ExportRender
 * Transform `default export` to defineRender.
 *
 * @deprecated Please use `ExportRenderV2` instead.
 *
 * @example
 * ```vue
 * <ExportRender />
 * ```
 */
export default () => <Ok />
</script>
```

#### Result
<img width="500" alt="image" src="https://github.com/vue-macros/vue-macros/assets/32807958/efba2c40-b9a3-4615-9cc1-c33be0940d2c">



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
