### PR TITLE
refactor(volar): use `scriptSetup.ast` instead of scriptSetupAst

### DIFF
--- a/packages/volar/src/common.ts
+++ b/packages/volar/src/common.ts
@@ -57,7 +57,7 @@ export function getImportNames(
   sfc: Sfc
 ) {
   const names: string[] = []
-  const sourceFile = sfc.scriptSetupAst!
+  const sourceFile = sfc.scriptSetup!.ast
   sourceFile.forEachChild((node) => {
     if (
       ts.isImportDeclaration(node) &&

--- a/packages/volar/src/define-models.ts
+++ b/packages/volar/src/define-models.ts
@@ -92,7 +92,7 @@ function getTypeArg(
     return node.typeArguments[0]
   }
 
-  const sourceFile = sfc.scriptSetupAst!
+  const sourceFile = sfc.scriptSetup!.ast
   return sourceFile.forEachChild((node) => {
     if (ts.isExpressionStatement(node)) {
       return getCallArg(node.expression)
@@ -116,7 +116,7 @@ const plugin: VueLanguagePlugin = ({
       if (
         embeddedFile.kind !== FileKind.TypeScriptHostFile ||
         !sfc.scriptSetup ||
-        !sfc.scriptSetupAst
+        !sfc.scriptSetup.ast
       )
         return
 

--- a/packages/volar/src/define-options.ts
+++ b/packages/volar/src/define-options.ts
@@ -39,7 +39,7 @@ function getArg(ts: typeof import('typescript/lib/tsserverlibrary'), sfc: Sfc) {
     return node.arguments[0]
   }
 
-  const sourceFile = sfc.scriptSetupAst!
+  const sourceFile = sfc.scriptSetup!.ast
   return sourceFile.forEachChild((node) => {
     if (ts.isExpressionStatement(node)) {
       return getCallArg(node.expression)
@@ -60,7 +60,7 @@ const plugin: VueLanguagePlugin = ({ modules: { typescript: ts } }) => {
       if (
         embeddedFile.kind !== FileKind.TypeScriptHostFile ||
         !sfc.scriptSetup ||
-        !sfc.scriptSetupAst
+        !sfc.scriptSetup.ast
       )
         return
 

--- a/packages/volar/src/define-slots.ts
+++ b/packages/volar/src/define-slots.ts
@@ -59,7 +59,7 @@ function getTypeArg(
     return node.typeArguments[0]
   }
 
-  return sfc.scriptSetupAst?.forEachChild((node) => {
+  return sfc.scriptSetup?.ast.forEachChild((node) => {
     if (ts.isExpressionStatement(node)) {
       return getCallArg(node.expression)
     } else if (ts.isVariableStatement(node)) {
@@ -82,7 +82,7 @@ const plugin: VueLanguagePlugin = ({
       if (
         embeddedFile.kind !== FileKind.TypeScriptHostFile ||
         !sfc.scriptSetup ||
-        !sfc.scriptSetupAst
+        !sfc.scriptSetup.ast
       )
         return
 

--- a/packages/volar/src/export-expose.ts
+++ b/packages/volar/src/export-expose.ts
@@ -34,21 +34,21 @@ function transform({
   const exposed: Record<string, Segment<FileRangeCapabilities>> = Object.create(
     null
   )
-  for (const stmt of sfc.scriptSetupAst!.statements) {
+  for (const stmt of sfc.scriptSetup!.ast.statements) {
     if (!ts.isVariableStatement(stmt)) continue
     const exportModifier = stmt.modifiers?.find(
       (m) => m.kind === ts.SyntaxKind.ExportKeyword
     )
     if (!exportModifier) continue
 
-    const start = exportModifier.getStart(sfc.scriptSetupAst!)
+    const start = exportModifier.getStart(sfc.scriptSetup?.ast)
     const end = exportModifier.getEnd()
     replaceSourceRange(file.content, 'scriptSetup', start, end)
 
     for (const decl of stmt.declarationList.declarations) {
       if (!ts.isIdentifier(decl.name)) continue
       const name = decl.name.text
-      const start = decl.name.getStart(sfc.scriptSetupAst!)
+      const start = decl.name.getStart(sfc.scriptSetup?.ast)
 
       exposed[name] = [name, 'scriptSetup', start, FileRangeCapabilities.full]
     }
@@ -82,7 +82,7 @@ const plugin: VueLanguagePlugin = ({
       if (
         embeddedFile.kind !== FileKind.TypeScriptHostFile ||
         !sfc.scriptSetup ||
-        !sfc.scriptSetupAst
+        !sfc.scriptSetup.ast
       )
         return
 

--- a/packages/volar/src/export-props.ts
+++ b/packages/volar/src/export-props.ts
@@ -32,14 +32,14 @@ function transform({
 
   const props: Record<string, boolean> = Object.create(null)
   let changed = false
-  for (const stmt of sfc.scriptSetupAst!.statements) {
+  for (const stmt of sfc.scriptSetup!.ast.statements) {
     if (!ts.isVariableStatement(stmt)) continue
     const exportModifier = stmt.modifiers?.find(
       (m) => m.kind === ts.SyntaxKind.ExportKeyword
     )
     if (!exportModifier) continue
 
-    const start = exportModifier.getStart(sfc.scriptSetupAst!)
+    const start = exportModifier.getStart(sfc.scriptSetup?.ast)
     const end = exportModifier.getEnd()
     replaceSourceRange(file.content, 'scriptSetup', start, end)
     changed = true
@@ -76,7 +76,7 @@ const plugin: VueLanguagePlugin = ({
       if (
         embeddedFile.kind !== FileKind.TypeScriptHostFile ||
         !sfc.scriptSetup ||
-        !sfc.scriptSetupAst
+        !sfc.scriptSetup.ast
       )
         return
 

--- a/packages/volar/src/export-render.ts
+++ b/packages/volar/src/export-render.ts
@@ -28,15 +28,15 @@ function transform({
   )
   if (!filter(fileName)) return
 
-  for (const stmt of sfc.scriptSetupAst!.statements) {
+  for (const stmt of sfc.scriptSetup!.ast.statements) {
     if (!ts.isExportAssignment(stmt)) continue
 
-    const start = stmt.expression.getStart(sfc.scriptSetupAst)
+    const start = stmt.expression.getStart(sfc.scriptSetup?.ast)
     const end = stmt.expression.getEnd()
     replaceSourceRange(
       file.content,
       'scriptSetup',
-      stmt.getStart(sfc.scriptSetupAst),
+      stmt.getStart(sfc.scriptSetup?.ast),
       start,
       'defineRender('
     )
@@ -55,7 +55,7 @@ const plugin: VueLanguagePlugin = ({
       if (
         embeddedFile.kind !== FileKind.TypeScriptHostFile ||
         !sfc.scriptSetup ||
-        !sfc.scriptSetupAst
+        !sfc.scriptSetup.ast
       )
         return
 

--- a/packages/volar/src/jsx-directive.ts
+++ b/packages/volar/src/jsx-directive.ts
@@ -332,12 +332,12 @@ function transformVModel({
   source,
 }: TransformOptions & { nodes: JsxAttributeNode[] }) {
   nodes.forEach(({ attribute }) => {
-    const start = attribute.getStart(sfc[`${source}Ast`])
+    const start = attribute.getStart(sfc[source]?.ast)
     let end = start + 7
     let name = 'modelValue'
 
     if (ts.isJsxNamespacedName(attribute.name)) {
-      name = attribute.name.name.getText(sfc[`${source}Ast`])
+      name = attribute.name.name.getText(sfc[source]?.ast)
       end += 1 + name.length
     }
 
@@ -402,7 +402,7 @@ function transformJsxDirective({
           (ts.isJsxNamespacedName(attribute.name)
             ? attribute.name.namespace
             : attribute.name
-          ).getText(sfc[`${source}Ast`])
+          ).getText(sfc[source]?.ast)
         )
       ) {
         vModelAttribute = attribute
@@ -437,7 +437,7 @@ function transformJsxDirective({
       )
     })
   }
-  sfc[`${source}Ast`]!.forEachChild(walkJsxDirective)
+  sfc[source]?.ast.forEachChild(walkJsxDirective)
 
   transformVSlot({
     nodes: Array.from(vSlotNodeSet),

--- a/packages/volar/src/setup-jsdoc.ts
+++ b/packages/volar/src/setup-jsdoc.ts
@@ -28,12 +28,12 @@ function transform({
   ts: typeof import('typescript/lib/tsserverlibrary')
 }) {
   let jsDoc
-  if (hasJSDocNodes(sfc.scriptSetupAst!.statements[0])) {
-    jsDoc = sfc.scriptSetupAst!.statements[0].jsDoc.at(-1)
+  if (hasJSDocNodes(sfc.scriptSetup!.ast.statements[0])) {
+    jsDoc = sfc.scriptSetup!.ast.statements[0].jsDoc.at(-1)
   }
 
   // With exportRender plugin.
-  for (const stmt of sfc.scriptSetupAst!.statements) {
+  for (const stmt of sfc.scriptSetup!.ast.statements) {
     if (!ts.isExportAssignment(stmt)) continue
 
     if (hasJSDocNodes(stmt)) jsDoc ??= stmt.jsDoc.at(-1)
@@ -56,7 +56,7 @@ const plugin: VueLanguagePlugin = ({ modules: { typescript: ts } }) => {
       if (
         embeddedFile.kind !== FileKind.TypeScriptHostFile ||
         !sfc.scriptSetup ||
-        !sfc.scriptSetupAst
+        !sfc.scriptSetup.ast
       )
         return
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
#### `scriptSetupAst` is deprecated.

https://github.com/vuejs/language-tools/pull/3682/files#diff-0392555b8e53eca0fe7a7eb4969db428df99bd65e096fe26b27f8face947988aR119

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
