### PR TITLE
fix(volar/jsx-directive): allow v-slot:default in template tag

### DIFF
--- a/.changeset/dirty-cats-repeat.md
+++ b/.changeset/dirty-cats-repeat.md
@@ -1,0 +1,5 @@
+---
+'@vue-macros/volar': patch
+---
+
+allow v-slot:default in template tag

--- a/packages/volar/src/jsx-directive.ts
+++ b/packages/volar/src/jsx-directive.ts
@@ -228,9 +228,11 @@ function transformVSlot({
           for (const attr of child.openingElement.attributes.properties) {
             if (!ts.isJsxAttribute(attr)) continue
             if (isTemplateTag) {
-              name = ts.isJsxNamespacedName(attr.name)
-                ? attr.name.name
-                : undefined
+              name =
+                ts.isJsxNamespacedName(attr.name) &&
+                attr.name.name.escapedText !== 'default'
+                  ? attr.name.name
+                  : undefined
             }
 
             if (

--- a/playground/vue3/src/examples/jsx-directive/v-slot/index.vue
+++ b/playground/vue3/src/examples/jsx-directive/v-slot/index.vue
@@ -16,7 +16,9 @@ defineRender(() => (
   <fieldset>
     <legend>v-slot</legend>
 
-    <Comp v-slot={{ foo }}>{''}</Comp>
+    <Comp>
+      <template v-slot:default={{ foo }}>{''}</template>
+    </Comp>
 
     <Child>
       <div>default: begin</div>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
![image](https://github.com/vue-macros/vue-macros/assets/32807958/060bb91b-d196-4775-8d21-6c126e03a737)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
