### PR TITLE
feat: compat for Vue 3.4

### DIFF
--- a/.changeset/rotten-buckets-agree.md
+++ b/.changeset/rotten-buckets-agree.md
@@ -1,0 +1,5 @@
+---
+'@vue-macros/setup-block': patch
+---
+
+compat for Vue 3.4

--- a/packages/setup-block/src/core/index.ts
+++ b/packages/setup-block/src/core/index.ts
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/prefer-ts-expect-error */
 import { MagicString, generateTransform } from '@vue-macros/common'
-import { type NodeTypes, parse, ElementNode } from '@vue/compiler-dom'
+import { type ElementNode, type NodeTypes, parse } from '@vue/compiler-dom'
 
 export function transformSetupBlock(code: string, id: string, lang?: string) {
   const s = new MagicString(code)

--- a/packages/setup-block/src/core/index.ts
+++ b/packages/setup-block/src/core/index.ts
@@ -1,15 +1,18 @@
 import { MagicString, generateTransform } from '@vue-macros/common'
-import { type NodeTypes, type TextModes, parse } from '@vue/compiler-dom'
+import { type NodeTypes, parse, ElementNode } from '@vue/compiler-dom'
 
 export function transformSetupBlock(code: string, id: string, lang?: string) {
   const s = new MagicString(code)
 
   const node = parse(code, {
+    // @ts-ignore TODO remove ignore in 3.4
+    parseMode: 'sfc',
     // there are no components at SFC parsing level
     isNativeTag: () => true,
     // preserve all whitespaces
     isPreTag: () => true,
-    getTextMode: ({ tag, props }, parent) => {
+    // @ts-ignore (this has been removed in Vue 3.4)
+    getTextMode: ({ tag, props }: ElementNode, parent) => {
       // all top level elements except <template> are parsed as raw text
       // containers
       if (
@@ -25,9 +28,9 @@ export function transformSetupBlock(code: string, id: string, lang?: string) {
               p.value.content !== 'html',
           ))
       ) {
-        return 2 satisfies TextModes.RAWTEXT
+        return 2
       } else {
-        return 0 satisfies TextModes.DATA
+        return 0
       }
     },
   })


### PR DESCRIPTION
Context: https://github.com/vuejs/core/pull/9674

- `TextModes` type and `getTextModes` option are removed in 3.4
- To get equivalent behavior, use the new option `parseMode: 'sfc'`

Since `getTextModes` is ignored in 3.4 and `parseMode` is ignored in 3.3, this should work for both versions.