### PR TITLE
fix(volar/jsx-directive): support v-model with no argument

### DIFF
--- a/packages/volar/src/jsx-directive/index.ts
+++ b/packages/volar/src/jsx-directive/index.ts
@@ -71,11 +71,7 @@ export function transformJsxDirective({
             : node,
         )
       }
-      if (
-        ts.isJsxNamespacedName(attribute.name)
-          ? attribute.name.namespace.getText(sfc[source]?.ast) === 'v-model'
-          : /^v-model(_\S+)?$/.test(attribute.name.getText(sfc[source]?.ast))
-      ) {
+      if (/^v-model[:_]?/.test(attribute.name.getText(sfc[source]?.ast))) {
         vModelAttributeMap.has(node) || vModelAttributeMap.set(node, [])
         vModelAttributeMap.get(node)!.push({
           node,

--- a/packages/volar/src/jsx-directive/v-model.ts
+++ b/packages/volar/src/jsx-directive/v-model.ts
@@ -16,8 +16,12 @@ export function transformVModel({
   let firstNamespacedNode: (JsxAttributeNode & { name: string }) | undefined
   const result: Segment<FileRangeCapabilities>[] = []
   for (const { attribute, node } of nodes) {
-    if (ts.isJsxNamespacedName(attribute.name)) {
-      const name = attribute.name.name.getText(sfc[source]?.ast).split('_')[0]
+    if (attribute.name.getText(sfc[source]?.ast).startsWith('v-model:')) {
+      const name = attribute.name
+        .getText(sfc[source]?.ast)
+        .slice(8)
+        .split(' ')[0]
+        .split('_')[0]
       firstNamespacedNode ??= { attribute, node, name }
       if (firstNamespacedNode.attribute !== attribute) {
         replaceSourceRange(
@@ -30,17 +34,18 @@ export function transformVModel({
       }
 
       result.push(
+        ',',
         [
           name,
           source,
           attribute.name.getStart(sfc[source]?.ast) + 8,
           FileRangeCapabilities.full,
         ],
-        attribute.initializer && attribute.name.name.getText?.(sfc[source]?.ast)
+        attribute.initializer && name
           ? [
               `:${attribute.initializer
                 .getText(sfc[source]?.ast)
-                .slice(1, -1)},`,
+                .slice(1, -1)}`,
               source,
               attribute.initializer.getStart(sfc[source]?.ast),
               FileRangeCapabilities.full,

--- a/packages/volar/src/jsx-directive/v-model.ts
+++ b/packages/volar/src/jsx-directive/v-model.ts
@@ -34,7 +34,7 @@ export function transformVModel({
       }
 
       result.push(
-        ',',
+        firstNamespacedNode.attribute !== attribute ? ',' : '',
         [
           name,
           source,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Support incorrect jsx-directive for `v-mode:`
<img width="338" alt="image" src="https://github.com/vue-macros/vue-macros/assets/32807958/623c1421-b251-49d7-8fc8-cee8a9db3de4">


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
