### PR TITLE
chore: set jsxImportSource in tsconfig for Vue 3.4

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "jsx": "preserve",
+    "jsxImportSource": "vue",
     "lib": ["ES2022"],
     "baseUrl": ".",
     "module": "ESNext",


### PR DESCRIPTION
global JSX types are removed in 3.4.