### PR TITLE
fix(reactivity-transform): `catch` scope

### DIFF
--- a/.changeset/unlucky-planes-watch.md
+++ b/.changeset/unlucky-planes-watch.md
@@ -2,4 +2,4 @@
 "@vue-macros/reactivity-transform": patch
 ---
 
-correctly pop scope of CatchClause
+fix `catch` scope of reactivity transform

--- a/.changeset/unlucky-planes-watch.md
+++ b/.changeset/unlucky-planes-watch.md
@@ -1,0 +1,5 @@
+---
+"@vue-macros/reactivity-transform": patch
+---
+
+correctly pop scope of CatchClause

--- a/packages/reactivity-transform/src/core/transform.ts
+++ b/packages/reactivity-transform/src/core/transform.ts
@@ -750,7 +750,8 @@ export function transformAST(
       parent && parentStack.pop()
       if (
         (node.type === 'BlockStatement' && !isFunctionType(parent!)) ||
-        isFunctionType(node)
+        isFunctionType(node) ||
+        node.type === 'CatchClause'
       ) {
         scopeStack.pop()
         currentScope = scopeStack.at(-1)!

--- a/packages/reactivity-transform/tests/__snapshots__/fixtures.test.ts.snap
+++ b/packages/reactivity-transform/tests/__snapshots__/fixtures.test.ts.snap
@@ -238,6 +238,31 @@ export { destructureProps as default };
 "
 `;
 
+exports[`fixtures > tests/fixtures/vue3/issue-608.vue 1`] = `
+"import { ref, isRef, defineComponent } from 'vue';
+import _export_sfc from '[NULL]/plugin-vue/export-helper';
+
+var _sfc_main = /* @__PURE__ */ defineComponent({
+  __name: "issue-608",
+  setup(__props) {
+    let ref$1 = ref("value");
+    console.log(isRef(ref$1.value));
+    try {
+    } catch {
+      const ref2 = "";
+    }
+    console.log(isRef(ref$1.value));
+    return () => {
+    };
+  }
+});
+
+var issue608 = /* @__PURE__ */ _export_sfc(_sfc_main, [__FILE__]);
+
+export { issue608 as default };
+"
+`;
+
 exports[`fixtures > tests/fixtures/vue3/runtime-default.vue 1`] = `
 "import { mergeDefaults, defineComponent } from 'vue';
 import _export_sfc from '[NULL]/plugin-vue/export-helper';

--- a/packages/reactivity-transform/tests/fixtures/vue3/issue-608.vue
+++ b/packages/reactivity-transform/tests/fixtures/vue3/issue-608.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { isRef } from 'vue'
+
+let ref = $ref('value')
+console.log(isRef(ref))
+
+try {
+} catch {
+  const ref = ''
+}
+
+console.log(isRef(ref))
+</script>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently, `reactivity-transform` doesn't correctly pop the scope stack when encountering a `CatchClause`. This causes it to get stuck in an incorrect scope, leading to confusing/wrong behaviour.

### Additional context

* [Here](https://github.com/vue-macros/vue-macros/blob/501fad4df5cc77f4c6e5c54afc122dba659b86c3/packages/reactivity-transform/src/core/transform.ts#L662)'s where the catch clause is pushed onto the stack
* ...but it's not checked for [here](https://github.com/vue-macros/vue-macros/blob/501fad4df5cc77f4c6e5c54afc122dba659b86c3/packages/reactivity-transform/src/core/transform.ts#L751).

### Reproduction code
```js
let ref = $ref("value");
console.log(isRef(ref)); // -> false
try {}
catch {
  const ref = "";
}
console.log(isRef(ref)); // -> true
```
