### PR TITLE
fix(volar/define-prop): $defineProp and defineSlots co-usage

### DIFF
--- a/docs/macros/define-prop.md
+++ b/docs/macros/define-prop.md
@@ -165,11 +165,9 @@ disabled.value
 // Kevin's Edition
 const foo = $defineProp('foo', { default: 'foo' })
 const bar = $(defineProp('bar', { default: 'bar', required: true }))
-console.log(foo, bar)
 
 // Johnson's Edition
 const foo = $defineProp('foo')
 const bar = $(defineProp('bar', true))
-console.log(foo, bar)
 </script>
 ```

--- a/docs/zh-CN/macros/define-prop.md
+++ b/docs/zh-CN/macros/define-prop.md
@@ -132,12 +132,10 @@ const disabled = defineProp<boolean>(true)
 // Kevin's Edition
 const foo = $defineProp('foo', { default: 'foo' })
 const bar = $(defineProp('bar', { default: 'bar', required: true }))
-console.log(foo, bar)
 
 // Johnson's Edition
 const foo = $defineProp('foo')
 const bar = $(defineProp('bar', true))
-console.log(foo, bar)
 </script>
 ```
 

--- a/packages/volar/src/define-prop.ts
+++ b/packages/volar/src/define-prop.ts
@@ -59,13 +59,13 @@ function transformDefineProp({
 type __VLS_PropOptions<T> = Exclude<
   import('${vueLibName}').Prop<T>,
   import('${vueLibName}').PropType<T>
->
+>;
 declare function $defineProp<T>(
   name: string,
   options: 
     | ({ default: T } & __VLS_PropOptions<T>)
     | ({ required: true } & __VLS_PropOptions<T>)
-): T
+): T;
 declare function $defineProp<T>(
   name?: string,
   options?: __VLS_PropOptions<T>
@@ -76,30 +76,30 @@ declare function $defineProp<T>(
     codes.push(`
 type __VLS_Widen<T> = T extends number | string | boolean | symbol
   ? ReturnType<T['valueOf']>
-  : T
+  : T;
 type __VLS_PropOptions<T> = Omit<
   Omit<
     Exclude<import('${vueLibName}').Prop<T>, import('${vueLibName}').PropType<T>>, 
     'default'
   >,
   'required'
->
+>;
 declare function $defineProp<T>(
   value: T | (() => T) | undefined,
   required: true,
   options?: __VLS_PropOptions<T>
-): __VLS_Widen<T>
+): __VLS_Widen<T>;
 declare function $defineProp<T>(
   value: T | (() => T),
   required?: boolean,
   options?: __VLS_PropOptions<T>
-): __VLS_Widen<T>
+): __VLS_Widen<T>;
 declare function $defineProp<T>(
   value?: T | (() => T),
   required?: boolean,
   options?: __VLS_PropOptions<T>
 ): | __VLS_Widen<T>
-   | undefined
+   | undefined;
 `)
   }
 }

--- a/packages/volar/src/define-prop.ts
+++ b/packages/volar/src/define-prop.ts
@@ -69,7 +69,8 @@ declare function $defineProp<T>(
 declare function $defineProp<T>(
   name?: string,
   options?: __VLS_PropOptions<T>
-): T | undefined`)
+): T | undefined;
+`)
   } else if (
     vueCompilerOptions.experimentalDefinePropProposal === 'johnsonEdition'
   ) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Missing a end semicolon

<img width="375" alt="image" src="https://github.com/vue-macros/vue-macros/assets/32807958/f27ab8ec-32ec-476d-8a6d-703ba3c5bde5">


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
