### PR TITLE
feat(boolean-prop): add support for negative prefix as false value

### DIFF
--- a/.changeset/famous-houses-melt.md
+++ b/.changeset/famous-houses-melt.md
@@ -1,0 +1,6 @@
+---
+"@vue-macros/boolean-prop": minor
+---
+
+support negative prefix
+  

--- a/docs/features/boolean-prop.md
+++ b/docs/features/boolean-prop.md
@@ -20,7 +20,7 @@ interface Options {
   /**
    * @default '!'
    */
-  prefix?: string
+  negativePrefix?: string
 }
 ```
 

--- a/docs/features/boolean-prop.md
+++ b/docs/features/boolean-prop.md
@@ -4,6 +4,8 @@
 
 Convert `<Comp checked />` to `<Comp :checked="true" />`.
 
+Convert `<Comp !checked />` to `<Comp :checked="false" />`.
+
 |   Features   |     Supported      |
 | :----------: | :----------------: |
 |    Vue 3     | :white_check_mark: |
@@ -11,11 +13,22 @@ Convert `<Comp checked />` to `<Comp :checked="true" />`.
 |    Vue 2     |        :x:         |
 | Volar Plugin | :white_check_mark: |
 
+## Options
+
+```ts
+interface Options {
+  /**
+   * @default '!'
+   */
+  prefix?: string
+}
+```
+
 ## Usage
 
 ```vue
 <template>
-  <Comp checked />
+  <Comp checked !enabled />
 </template>
 ```
 
@@ -24,6 +37,7 @@ Convert `<Comp checked />` to `<Comp :checked="true" />`.
 // Comp.vue
 defineProps<{
   checked?: any
+  enabled: boolean
 }>()
 </script>
 ```

--- a/docs/zh-CN/features/boolean-prop.md
+++ b/docs/zh-CN/features/boolean-prop.md
@@ -20,7 +20,7 @@ interface Options {
   /**
    * @default '!'
    */
-  prefix?: string
+  negativePrefix?: string
 }
 ```
 

--- a/docs/zh-CN/features/boolean-prop.md
+++ b/docs/zh-CN/features/boolean-prop.md
@@ -4,6 +4,8 @@
 
 把 `<Comp checked />` 转换为 `<Comp :checked="true" />`。
 
+把 `<Comp !checked />` 转换为 `<Comp :checked="false" />`。
+
 |   Features   |     Supported      |
 | :----------: | :----------------: |
 |    Vue 3     | :white_check_mark: |
@@ -11,11 +13,22 @@
 |    Vue 2     |        :x:         |
 | Volar Plugin | :white_check_mark: |
 
+## 选项
+
+```ts
+interface Options {
+  /**
+   * @default '!'
+   */
+  prefix?: string
+}
+```
+
 ## 基本用法
 
 ```vue
 <template>
-  <Comp checked />
+  <Comp checked !enabled />
 </template>
 ```
 
@@ -24,6 +37,7 @@
 // Comp.vue
 defineProps<{
   checked?: any
+  enabled: boolean
 }>()
 </script>
 ```

--- a/packages/boolean-prop/src/core/transformer.ts
+++ b/packages/boolean-prop/src/core/transformer.ts
@@ -8,11 +8,11 @@ export interface Options {
   /**
    * @default '!'
    */
-  prefix?: string
+  negativePrefix?: string
 }
 
 export function transformBooleanProp(
-  options: Options = { prefix: '!' },
+  options: Options = { negativePrefix: '!' },
 ): NodeTransform {
   return (node) => {
     if (node.type !== (1 satisfies NodeTypes.ELEMENT)) return
@@ -23,9 +23,9 @@ export function transformBooleanProp(
       )
         continue
 
-      let { prefix } = options
-      prefix ||= '!'
-      if (prop.name.slice(0, 1) === prefix) {
+      let { negativePrefix } = options
+      negativePrefix ||= '!'
+      if (prop.name.slice(0, 1) === negativePrefix) {
         const propName = prop.name.slice(1)
         node.props[i] = {
           type: 7 satisfies NodeTypes.DIRECTIVE,

--- a/packages/boolean-prop/src/core/transformer.ts
+++ b/packages/boolean-prop/src/core/transformer.ts
@@ -11,9 +11,9 @@ export interface Options {
   negativePrefix?: string
 }
 
-export function transformBooleanProp(
-  options: Options = { negativePrefix: '!' },
-): NodeTransform {
+export function transformBooleanProp({
+  negativePrefix = '!',
+}: Options = {}): NodeTransform {
   return (node) => {
     if (node.type !== (1 satisfies NodeTypes.ELEMENT)) return
     for (const [i, prop] of node.props.entries()) {
@@ -23,51 +23,27 @@ export function transformBooleanProp(
       )
         continue
 
-      let { negativePrefix } = options
-      negativePrefix ||= '!'
-      if (prop.name.slice(0, 1) === negativePrefix) {
-        const propName = prop.name.slice(1)
-        node.props[i] = {
-          type: 7 satisfies NodeTypes.DIRECTIVE,
-          name: 'bind',
-          arg: {
-            type: 4 satisfies NodeTypes.SIMPLE_EXPRESSION,
-            constType: 3 satisfies ConstantTypes.CAN_STRINGIFY,
-            content: propName,
-            isStatic: true,
-            loc: prop.loc,
-          },
-          exp: {
-            type: 4 satisfies NodeTypes.SIMPLE_EXPRESSION,
-            constType: 3 satisfies ConstantTypes.CAN_STRINGIFY,
-            content: 'false',
-            isStatic: false,
-            loc: prop.loc,
-          },
+      const isNegative = prop.name[0] === negativePrefix
+      const propName = isNegative ? prop.name.slice(1) : prop.name
+      node.props[i] = {
+        type: 7 satisfies NodeTypes.DIRECTIVE,
+        name: 'bind',
+        arg: {
+          type: 4 satisfies NodeTypes.SIMPLE_EXPRESSION,
+          constType: 3 satisfies ConstantTypes.CAN_STRINGIFY,
+          content: propName,
+          isStatic: true,
           loc: prop.loc,
-          modifiers: [],
-        }
-      } else {
-        node.props[i] = {
-          type: 7 satisfies NodeTypes.DIRECTIVE,
-          name: 'bind',
-          arg: {
-            type: 4 satisfies NodeTypes.SIMPLE_EXPRESSION,
-            constType: 3 satisfies ConstantTypes.CAN_STRINGIFY,
-            content: prop.name,
-            isStatic: true,
-            loc: prop.loc,
-          },
-          exp: {
-            type: 4 satisfies NodeTypes.SIMPLE_EXPRESSION,
-            constType: 3 satisfies ConstantTypes.CAN_STRINGIFY,
-            content: 'true',
-            isStatic: false,
-            loc: prop.loc,
-          },
+        },
+        exp: {
+          type: 4 satisfies NodeTypes.SIMPLE_EXPRESSION,
+          constType: 3 satisfies ConstantTypes.CAN_STRINGIFY,
+          content: String(!isNegative),
+          isStatic: false,
           loc: prop.loc,
-          modifiers: [],
-        }
+        },
+        loc: prop.loc,
+        modifiers: [],
       }
     }
   }

--- a/packages/boolean-prop/src/core/transformer.ts
+++ b/packages/boolean-prop/src/core/transformer.ts
@@ -1,4 +1,3 @@
-import type { BaseOptions } from '@vue-macros/common'
 import type {
   ConstantTypes,
   NodeTransform,

--- a/packages/boolean-prop/tests/__snapshots__/compiler.test.ts.snap
+++ b/packages/boolean-prop/tests/__snapshots__/compiler.test.ts.snap
@@ -58,3 +58,121 @@ exports[`compiler > basic 1`] = `
   "type": 7,
 }
 `;
+
+exports[`compiler > false prop 1`] = `
+{
+  "arg": {
+    "constType": 3,
+    "content": "checked",
+    "isStatic": true,
+    "loc": {
+      "end": {
+        "column": 16,
+        "line": 1,
+        "offset": 15,
+      },
+      "source": "!checked",
+      "start": {
+        "column": 8,
+        "line": 1,
+        "offset": 7,
+      },
+    },
+    "type": 4,
+  },
+  "exp": {
+    "constType": 3,
+    "content": "false",
+    "isStatic": false,
+    "loc": {
+      "end": {
+        "column": 16,
+        "line": 1,
+        "offset": 15,
+      },
+      "source": "!checked",
+      "start": {
+        "column": 8,
+        "line": 1,
+        "offset": 7,
+      },
+    },
+    "type": 4,
+  },
+  "loc": {
+    "end": {
+      "column": 16,
+      "line": 1,
+      "offset": 15,
+    },
+    "source": "!checked",
+    "start": {
+      "column": 8,
+      "line": 1,
+      "offset": 7,
+    },
+  },
+  "modifiers": [],
+  "name": "bind",
+  "type": 7,
+}
+`;
+
+exports[`compiler > false prop prefix 1`] = `
+{
+  "arg": {
+    "constType": 3,
+    "content": "checked",
+    "isStatic": true,
+    "loc": {
+      "end": {
+        "column": 16,
+        "line": 1,
+        "offset": 15,
+      },
+      "source": "~checked",
+      "start": {
+        "column": 8,
+        "line": 1,
+        "offset": 7,
+      },
+    },
+    "type": 4,
+  },
+  "exp": {
+    "constType": 3,
+    "content": "false",
+    "isStatic": false,
+    "loc": {
+      "end": {
+        "column": 16,
+        "line": 1,
+        "offset": 15,
+      },
+      "source": "~checked",
+      "start": {
+        "column": 8,
+        "line": 1,
+        "offset": 7,
+      },
+    },
+    "type": 4,
+  },
+  "loc": {
+    "end": {
+      "column": 16,
+      "line": 1,
+      "offset": 15,
+    },
+    "source": "~checked",
+    "start": {
+      "column": 8,
+      "line": 1,
+      "offset": 7,
+    },
+  },
+  "modifiers": [],
+  "name": "bind",
+  "type": 7,
+}
+`;

--- a/packages/boolean-prop/tests/compiler.test.ts
+++ b/packages/boolean-prop/tests/compiler.test.ts
@@ -2,13 +2,17 @@ import { compileTemplate } from '@vue/compiler-sfc'
 import { describe, expect, test } from 'vitest'
 import { transformBooleanProp } from '../src'
 
-function compile(code: string) {
+function compile(code: string, prefix?: string) {
   return compileTemplate({
     source: code,
     filename: 'anonymous.vue',
     id: 'xxx',
     compilerOptions: {
-      nodeTransforms: [transformBooleanProp()],
+      nodeTransforms: [
+        transformBooleanProp({
+          prefix,
+        }),
+      ],
     },
   })
 }
@@ -17,6 +21,20 @@ describe('compiler', () => {
   test('basic', () => {
     const original = compile(`<input :checked="true" />`)
     const sugar = compile(`<input checked />`)
+    expect(sugar.code).toBe(original.code)
+    expect((sugar.ast as any).children[0].props[0]).matchSnapshot()
+  })
+
+  test('false prop', () => {
+    const original = compile(`<input :checked="false" />`)
+    const sugar = compile(`<input !checked />`)
+    expect(sugar.code).toBe(original.code)
+    expect((sugar.ast as any).children[0].props[0]).matchSnapshot()
+  })
+
+  test('false prop prefix', () => {
+    const original = compile(`<input :checked="false" !w-5 />`, '~')
+    const sugar = compile(`<input ~checked !w-5 />`, '~')
     expect(sugar.code).toBe(original.code)
     expect((sugar.ast as any).children[0].props[0]).matchSnapshot()
   })

--- a/packages/boolean-prop/tests/compiler.test.ts
+++ b/packages/boolean-prop/tests/compiler.test.ts
@@ -2,7 +2,7 @@ import { compileTemplate } from '@vue/compiler-sfc'
 import { describe, expect, test } from 'vitest'
 import { transformBooleanProp } from '../src'
 
-function compile(code: string, prefix?: string) {
+function compile(code: string, negativePrefix?: string) {
   return compileTemplate({
     source: code,
     filename: 'anonymous.vue',
@@ -10,7 +10,7 @@ function compile(code: string, prefix?: string) {
     compilerOptions: {
       nodeTransforms: [
         transformBooleanProp({
-          prefix,
+          negativePrefix,
         }),
       ],
     },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR introduce a short false prop for `booleanProp` macros.

#### Usage
```
<Comp !checked /> 
```

Will be convert to:
```
<Comp :checked="false" />
```

And the "!" prefix can be custom too.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

By the way, I think the `Convert <Comp checked /> to <Comp :checked="true" /> maros` should be removed, It's vue's default behavior, right?

<!-- e.g. is there anything you'd like reviewers to focus on? -->
