### PR TITLE
chore: upgrade vue to 3.5.2

### DIFF
--- a/packages/macros/tests/__snapshots__/fixtures.test.ts.snap
+++ b/packages/macros/tests/__snapshots__/fixtures.test.ts.snap
@@ -129,7 +129,7 @@ const propName = 'title';
 const __default__ = defineComponent({
   name,
 });
-const _sfc_main = /*#__PURE__*/Object.assign(__default__, {
+const _sfc_main = /*@__PURE__*/Object.assign(__default__, {
   props: [propName],
   setup(__props, { expose: __expose }) {
   __expose();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@vue/compiler-core':
-      specifier: ^3.5.0
-      version: 3.5.0
+      specifier: ^3.5.2
+      version: 3.5.2
     '@vue/compiler-dom':
-      specifier: ^3.5.0
-      version: 3.5.0
+      specifier: ^3.5.2
+      version: 3.5.2
     '@vue/compiler-sfc':
-      specifier: ^3.5.0
-      version: 3.5.0
+      specifier: ^3.5.2
+      version: 3.5.2
     '@vue/language-core':
       specifier: 2.0.29
       version: 2.0.29
     '@vue/shared':
-      specifier: ^3.5.0
-      version: 3.5.0
+      specifier: ^3.5.2
+      version: 3.5.2
     typescript:
       specifier: 5.6.1-rc
       version: 5.6.1-rc
@@ -260,11 +260,11 @@ importers:
         version: link:../common
       '@vue/compiler-core':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
     devDependencies:
       '@vue/compiler-sfc':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
 
   packages/chain-call:
     dependencies:
@@ -285,7 +285,7 @@ importers:
         version: 5.1.0(rollup@4.21.2)
       '@vue/compiler-sfc':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
       ast-kit:
         specifier: ^1.1.0
         version: 1.1.0
@@ -560,7 +560,7 @@ importers:
         version: link:../common
       '@vue/compiler-sfc':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
       unplugin:
         specifier: 'catalog:'
         version: 1.12.3
@@ -720,7 +720,7 @@ importers:
         version: link:../common
       '@vue/compiler-dom':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
       unplugin:
         specifier: 'catalog:'
         version: 1.12.3
@@ -761,10 +761,10 @@ importers:
         version: link:../common
       '@vue/compiler-core':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
       '@vue/shared':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
       magic-string:
         specifier: ^0.30.11
         version: 0.30.11
@@ -792,7 +792,7 @@ importers:
         version: link:../common
       '@vue/compiler-dom':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
       unplugin:
         specifier: 'catalog:'
         version: 1.12.3
@@ -830,11 +830,11 @@ importers:
         version: link:../common
       '@vue/compiler-core':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
     devDependencies:
       '@vue/compiler-sfc':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
 
   packages/short-emits:
     dependencies:
@@ -852,11 +852,11 @@ importers:
         version: link:../common
       '@vue/compiler-core':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
     devDependencies:
       '@vue/compiler-sfc':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
 
   packages/test-utils:
     dependencies:
@@ -918,7 +918,7 @@ importers:
     devDependencies:
       '@vue/compiler-dom':
         specifier: 'catalog:'
-        version: 3.5.0
+        version: 3.5.2
       typescript:
         specifier: 'catalog:'
         version: 5.6.1-rc
@@ -2710,14 +2710,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.5.0':
-    resolution: {integrity: sha512-ja7cpqAOfw4tyFAxgBz70Z42miNDeaqTxExTsnXDLomRpqfyCgyvZvFp482fmsElpfvsoMJUsvzULhvxUTW6Iw==}
-
   '@vue/compiler-core@3.5.2':
     resolution: {integrity: sha512-1aP7FL2GkqfcskHWGg3lfWQpJnrmewKc+rNJ/hq9WNaAw4BEyJ5QbNChnqmbw+tJ409zdy1XWmUeXXMrCKJcQQ==}
-
-  '@vue/compiler-dom@3.5.0':
-    resolution: {integrity: sha512-xYjUybWZXl+1R/toDy815i4PbeehL2hThiSGkcpmIOCy2HoYyeeC/gAWK/Y/xsoK+GSw198/T5O31bYuQx5uvQ==}
 
   '@vue/compiler-dom@3.5.2':
     resolution: {integrity: sha512-QY4DpT8ZIUyu/ZA5gErpSEDocGNEbHmpkZIC/d5jbp/rUF0iOJNigAy3HCCKc0PMMhDlrcysO3ufQ6Ab4MpEcQ==}
@@ -2725,14 +2719,8 @@ packages:
   '@vue/compiler-sfc@2.7.16':
     resolution: {integrity: sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==}
 
-  '@vue/compiler-sfc@3.5.0':
-    resolution: {integrity: sha512-B9DgLtrqok2GLuaFjLlSL15ZG3ZDBiitUH1ecex9guh/ZcA5MCdwuVE6nsfQxktuZY/QY0awJ35/ripIviCQTQ==}
-
   '@vue/compiler-sfc@3.5.2':
     resolution: {integrity: sha512-vErEtybSU290LbMW+ChYllI9tNJEdTW1oU+8cZWINZyjlWeTSa9YqDl4/pZJSnozOI+HmcaC1Vz2eFKmXNSXZA==}
-
-  '@vue/compiler-ssr@3.5.0':
-    resolution: {integrity: sha512-E263QZmA1dqRd7c3u/sWTLRMpQOT0aZ8av/L9SoD/v/BVMZaWFHPUUBswS+bzrfvG2suJF8vSLKx6k6ba5SUdA==}
 
   '@vue/compiler-ssr@3.5.2':
     resolution: {integrity: sha512-vMtA4tQK/AM3UAYJsmouQzQpgG+h9TKiD5BV+Zt+ZyAMdicxzSEEFGWf/CykRnDpqj9fMfIHPhOezJVNxiXe2A==}
@@ -2768,9 +2756,6 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.5.0':
-    resolution: {integrity: sha512-Ew3F5riP3B3ZDGjD3ZKb9uZylTTPSqt8hAf4sGbvbjrjDjrFb3Jm15Tk1/w7WwTE5GbQ2Qhwxx1moc9hr8A/OQ==}
-
   '@vue/reactivity@3.5.2':
     resolution: {integrity: sha512-lJwWL5bNht+2vIwU/+lnGdH+FKFxzz6z8WkoIJityPLiasWU+HDUvEsC7gm3JFwbTf7Kk+Nr9kJMaPy0HXwwxQ==}
 
@@ -2784,9 +2769,6 @@ packages:
     resolution: {integrity: sha512-3POhYCA8KfbmuDuUiNbMXnpdh9pwE4SvAqo7VvACjklLkf3AaMkY3TvV7APeEa/WQezrnL+E4X2ASpJsKeS4cQ==}
     peerDependencies:
       vue: 3.5.2
-
-  '@vue/shared@3.5.0':
-    resolution: {integrity: sha512-m9IgiteBpCkFaMNwCOBkFksA7z8QiKc30ooRuoXWUFRDu0mGyNPlFHmbncF0/Kra1RlX8QrmBbRaIxVvikaR0Q==}
 
   '@vue/shared@3.5.2':
     resolution: {integrity: sha512-Ce89WNFBzcDca/AgFTxgX4/K4iAyF7oFIp8Z5aBbFBNbtpwnQr+5pZOoHndxnjE2h+YFcipVMzs9UL11XB6dwA==}
@@ -6252,7 +6234,7 @@ snapshots:
     dependencies:
       '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-sfc': 3.5.0
+      '@vue/compiler-sfc': 3.5.2
       astro: 4.15.2(@types/node@22.5.2)(less@4.2.0)(rollup@4.21.2)(terser@5.31.6)(typescript@5.6.1-rc)
       vite-plugin-vue-devtools: 7.3.9(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       vue: 3.5.2(typescript@5.6.1-rc)
@@ -8141,7 +8123,7 @@ snapshots:
   '@vue-macros/boolean-prop@0.4.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-core': 3.5.0
+      '@vue/compiler-core': 3.5.2
     transitivePeerDependencies:
       - rollup
       - vue
@@ -8158,7 +8140,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.6
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
-      '@vue/compiler-sfc': 3.5.0
+      '@vue/compiler-sfc': 3.5.2
       ast-kit: 1.1.0
       local-pkg: 0.5.0
       magic-string-ast: 0.6.2
@@ -8251,7 +8233,7 @@ snapshots:
   '@vue-macros/export-expose@0.2.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-sfc': 3.5.0
+      '@vue/compiler-sfc': 3.5.2
       unplugin: 1.12.3
       vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
@@ -8268,7 +8250,7 @@ snapshots:
   '@vue-macros/export-render@0.2.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-sfc': 3.5.0
+      '@vue/compiler-sfc': 3.5.2
       unplugin: 1.12.3
       vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
@@ -8294,7 +8276,7 @@ snapshots:
   '@vue-macros/named-template@0.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-dom': 3.5.0
+      '@vue/compiler-dom': 3.5.2
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
@@ -8304,8 +8286,8 @@ snapshots:
     dependencies:
       '@babel/parser': 7.25.6
       '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-core': 3.5.0
-      '@vue/shared': 3.5.0
+      '@vue/compiler-core': 3.5.2
+      '@vue/shared': 3.5.2
       magic-string: 0.30.11
       unplugin: 1.12.3
       vue: 3.5.2(typescript@5.6.1-rc)
@@ -8323,7 +8305,7 @@ snapshots:
   '@vue-macros/setup-block@0.3.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-dom': 3.5.0
+      '@vue/compiler-dom': 3.5.2
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
@@ -8348,7 +8330,7 @@ snapshots:
   '@vue-macros/short-bind@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-core': 3.5.0
+      '@vue/compiler-core': 3.5.2
     transitivePeerDependencies:
       - rollup
       - vue
@@ -8364,7 +8346,7 @@ snapshots:
   '@vue-macros/short-vmodel@1.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
-      '@vue/compiler-core': 3.5.0
+      '@vue/compiler-core': 3.5.2
     transitivePeerDependencies:
       - rollup
       - vue
@@ -8417,7 +8399,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/parser': 7.25.6
-      '@vue/compiler-sfc': 3.5.0
+      '@vue/compiler-sfc': 3.5.2
 
   '@vue/babel-plugin-transform-vue-jsx@1.4.0(@babel/core@7.25.2)':
     dependencies:
@@ -8488,14 +8470,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/compiler-core@3.5.0':
-    dependencies:
-      '@babel/parser': 7.25.6
-      '@vue/shared': 3.5.0
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.0
-
   '@vue/compiler-core@3.5.2':
     dependencies:
       '@babel/parser': 7.25.6
@@ -8503,11 +8477,6 @@ snapshots:
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.0
-
-  '@vue/compiler-dom@3.5.0':
-    dependencies:
-      '@vue/compiler-core': 3.5.0
-      '@vue/shared': 3.5.0
 
   '@vue/compiler-dom@3.5.2':
     dependencies:
@@ -8522,18 +8491,6 @@ snapshots:
     optionalDependencies:
       prettier: 2.8.8
 
-  '@vue/compiler-sfc@3.5.0':
-    dependencies:
-      '@babel/parser': 7.25.6
-      '@vue/compiler-core': 3.5.0
-      '@vue/compiler-dom': 3.5.0
-      '@vue/compiler-ssr': 3.5.0
-      '@vue/shared': 3.5.0
-      estree-walker: 2.0.2
-      magic-string: 0.30.11
-      postcss: 8.4.44
-      source-map-js: 1.2.0
-
   '@vue/compiler-sfc@3.5.2':
     dependencies:
       '@babel/parser': 7.25.6
@@ -8545,11 +8502,6 @@ snapshots:
       magic-string: 0.30.11
       postcss: 8.4.44
       source-map-js: 1.2.0
-
-  '@vue/compiler-ssr@3.5.0':
-    dependencies:
-      '@vue/compiler-dom': 3.5.0
-      '@vue/shared': 3.5.0
 
   '@vue/compiler-ssr@3.5.2':
     dependencies:
@@ -8615,19 +8567,15 @@ snapshots:
   '@vue/language-core@2.0.29(typescript@5.6.1-rc)':
     dependencies:
       '@volar/language-core': 2.4.1
-      '@vue/compiler-dom': 3.5.0
+      '@vue/compiler-dom': 3.5.2
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.0
+      '@vue/shared': 3.5.2
       computeds: 0.0.1
       minimatch: 9.0.5
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.6.1-rc
-
-  '@vue/reactivity@3.5.0':
-    dependencies:
-      '@vue/shared': 3.5.0
 
   '@vue/reactivity@3.5.2':
     dependencies:
@@ -8650,8 +8598,6 @@ snapshots:
       '@vue/compiler-ssr': 3.5.2
       '@vue/shared': 3.5.2
       vue: 3.5.2(typescript@5.6.1-rc)
-
-  '@vue/shared@3.5.0': {}
 
   '@vue/shared@3.5.2': {}
 
@@ -12109,7 +12055,7 @@ snapshots:
 
   unplugin-vue@5.1.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)(vue@3.5.2(typescript@5.6.1-rc)):
     dependencies:
-      '@vue/reactivity': 3.5.0
+      '@vue/reactivity': 3.5.2
       debug: 4.3.6
       unplugin: 1.12.3
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
@@ -12274,7 +12220,7 @@ snapshots:
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2)
       '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.25.2)
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.25.2)
-      '@vue/compiler-dom': 3.5.0
+      '@vue/compiler-dom': 3.5.2
       kolorist: 1.8.0
       magic-string: 0.30.11
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
@@ -12313,7 +12259,7 @@ snapshots:
       '@types/markdown-it': 14.1.2
       '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/devtools-api': 7.3.9
-      '@vue/shared': 3.5.0
+      '@vue/shared': 3.5.2
       '@vueuse/core': 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
       '@vueuse/integrations': 11.0.3(focus-trap@7.5.4)(vue@3.5.2(typescript@5.6.1-rc))
       focus-trap: 7.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^5.4.3
       version: 5.4.3
     vue:
-      specifier: ^3.5.0
-      version: 3.5.0
+      specifier: ^3.5.2
+      version: 3.5.2
     vue-tsc:
       specifier: 2.0.29
       version: 2.0.29
@@ -153,7 +153,7 @@ importers:
         version: 2.0.5(@types/node@22.5.2)(@vitest/ui@2.0.5)(less@4.2.0)(terser@5.31.6)
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
       vue-tsc:
         specifier: 'catalog:'
         version: 2.0.29(typescript@5.6.1-rc)
@@ -193,19 +193,19 @@ importers:
         version: 1.16.1(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(typescript@5.6.1-rc)
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.0.1
-        version: 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vue-macros/volar':
         specifier: npm:@vue-macros/volar@^0.27.4
-        version: 0.27.4(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc)))(rollup@4.21.2)(typescript@5.6.1-rc)(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 0.27.4(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc)))(rollup@4.21.2)(typescript@5.6.1-rc)(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.2(typescript@5.6.1-rc))
       '@vueuse/core':
         specifier: ^11.0.3
-        version: 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
+        version: 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
       unplugin-vue-macros:
         specifier: npm:unplugin-vue-macros@^2.11.5
-        version: 2.11.6(@rspack/core@1.0.1)(@vueuse/core@11.0.3(vue@3.5.0(typescript@5.6.1-rc)))(esbuild@0.23.1)(rolldown@0.13.0)(rollup@4.21.2)(typescript@5.6.1-rc)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.0(typescript@5.6.1-rc))(webpack@5.94.0(esbuild@0.23.1))
+        version: 2.11.6(@rspack/core@1.0.1)(@vueuse/core@11.0.3(vue@3.5.2(typescript@5.6.1-rc)))(esbuild@0.23.1)(rolldown@0.13.0)(rollup@4.21.2)(typescript@5.6.1-rc)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.2(typescript@5.6.1-rc))(webpack@5.94.0(esbuild@0.23.1))
       vite-plugin-vue-devtools:
         specifier: ^7.3.9
-        version: 7.3.9(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 7.3.9(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       vitepress:
         specifier: ^1.3.4
         version: 1.3.4(@algolia/client-search@4.24.0)(@types/node@22.5.2)(less@4.2.0)(postcss@8.4.44)(terser@5.31.6)(typescript@5.6.1-rc)
@@ -214,7 +214,7 @@ importers:
         version: 1.1.0
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/api:
     dependencies:
@@ -236,7 +236,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.1.3
-        version: 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       astro:
         specifier: ^4.15.2
         version: 4.15.2(@types/node@22.5.2)(less@4.2.0)(rollup@4.21.2)(terser@5.31.6)(typescript@5.6.1-rc)
@@ -301,7 +301,7 @@ importers:
         version: 7.25.6
       '@vitejs/plugin-vue':
         specifier: ^5.1.3
-        version: 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
 
   packages/config:
     dependencies:
@@ -408,7 +408,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/define-models:
     dependencies:
@@ -427,10 +427,10 @@ importers:
         version: link:../api
       '@vueuse/core':
         specifier: ^11.0.3
-        version: 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
+        version: 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/define-options:
     dependencies:
@@ -446,7 +446,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/define-prop:
     dependencies:
@@ -462,7 +462,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/define-props:
     dependencies:
@@ -478,7 +478,7 @@ importers:
         version: link:../reactivity-transform
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/define-props-refs:
     dependencies:
@@ -491,7 +491,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/define-render:
     dependencies:
@@ -504,7 +504,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/define-slots:
     dependencies:
@@ -517,7 +517,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/devtools:
     dependencies:
@@ -526,14 +526,14 @@ importers:
         version: 2.0.4
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
     devDependencies:
       '@unocss/reset':
         specifier: ^0.62.3
         version: 0.62.3
       '@vitejs/plugin-vue':
         specifier: ^5.1.3
-        version: 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -567,7 +567,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/export-props:
     dependencies:
@@ -580,7 +580,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/export-render:
     dependencies:
@@ -593,7 +593,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/hoist-static:
     dependencies:
@@ -614,7 +614,7 @@ importers:
         version: 1.12.3
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/macros:
     dependencies:
@@ -711,7 +711,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/named-template:
     dependencies:
@@ -727,7 +727,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/nuxt:
     dependencies:
@@ -783,7 +783,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/setup-block:
     dependencies:
@@ -808,7 +808,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/setup-sfc:
     dependencies:
@@ -821,7 +821,7 @@ importers:
     devDependencies:
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/short-bind:
     dependencies:
@@ -871,10 +871,10 @@ importers:
         version: 0.2.1(vitest@2.0.5(@types/node@22.5.2)(@vitest/ui@2.0.5)(less@4.2.0)(terser@5.31.6))
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.0.1
-        version: 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vitejs/plugin-vue2':
         specifier: ^2.3.1
-        version: 2.3.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 2.3.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       rollup:
         specifier: ^4.21.2
         version: 4.21.2
@@ -883,14 +883,14 @@ importers:
         version: 6.1.1(esbuild@0.23.1)(rollup@4.21.2)
       unplugin-vue:
         specifier: ^5.1.3
-        version: 5.1.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)(vue@3.5.0(typescript@5.6.1-rc))
+        version: 5.1.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)(vue@3.5.2(typescript@5.6.1-rc))
     devDependencies:
       vite:
         specifier: 'catalog:'
         version: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   packages/volar:
     dependencies:
@@ -930,13 +930,13 @@ importers:
     dependencies:
       '@astrojs/vue':
         specifier: ^4.5.0
-        version: 4.5.0(astro@4.15.2(@types/node@22.5.2)(less@4.2.0)(rollup@4.21.2)(terser@5.31.6)(typescript@5.6.1-rc))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 4.5.0(astro@4.15.2(@types/node@22.5.2)(less@4.2.0)(rollup@4.21.2)(terser@5.31.6)(typescript@5.6.1-rc))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vue-macros/astro':
         specifier: workspace:*
         version: link:../../packages/astro
       '@vueuse/core':
         specifier: ^11.0.3
-        version: 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
+        version: 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
       astro:
         specifier: ^4.15.2
         version: 4.15.2(@types/node@22.5.2)(less@4.2.0)(rollup@4.21.2)(terser@5.31.6)(typescript@5.6.1-rc)
@@ -945,7 +945,7 @@ importers:
         version: link:../../packages/macros
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
 
   playground/vue2:
     dependencies:
@@ -1012,13 +1012,13 @@ importers:
     dependencies:
       '@vueuse/core':
         specifier: ^11.0.3
-        version: 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
+        version: 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
       quasar:
         specifier: ^2.16.9
         version: 2.16.9
       vue:
         specifier: 'catalog:'
-        version: 3.5.0(typescript@5.6.1-rc)
+        version: 3.5.2(typescript@5.6.1-rc)
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^26.0.1
@@ -1028,10 +1028,10 @@ importers:
         version: 15.2.3(rollup@4.21.2)
       '@vitejs/plugin-vue':
         specifier: ^5.1.3
-        version: 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.0.1
-        version: 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+        version: 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
@@ -1055,7 +1055,7 @@ importers:
         version: 0.62.3(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))
       unplugin-vue:
         specifier: ^5.1.3
-        version: 5.1.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)(vue@3.5.0(typescript@5.6.1-rc))
+        version: 5.1.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin-vue-macros:
         specifier: workspace:*
         version: link:../../packages/macros
@@ -2713,8 +2713,14 @@ packages:
   '@vue/compiler-core@3.5.0':
     resolution: {integrity: sha512-ja7cpqAOfw4tyFAxgBz70Z42miNDeaqTxExTsnXDLomRpqfyCgyvZvFp482fmsElpfvsoMJUsvzULhvxUTW6Iw==}
 
+  '@vue/compiler-core@3.5.2':
+    resolution: {integrity: sha512-1aP7FL2GkqfcskHWGg3lfWQpJnrmewKc+rNJ/hq9WNaAw4BEyJ5QbNChnqmbw+tJ409zdy1XWmUeXXMrCKJcQQ==}
+
   '@vue/compiler-dom@3.5.0':
     resolution: {integrity: sha512-xYjUybWZXl+1R/toDy815i4PbeehL2hThiSGkcpmIOCy2HoYyeeC/gAWK/Y/xsoK+GSw198/T5O31bYuQx5uvQ==}
+
+  '@vue/compiler-dom@3.5.2':
+    resolution: {integrity: sha512-QY4DpT8ZIUyu/ZA5gErpSEDocGNEbHmpkZIC/d5jbp/rUF0iOJNigAy3HCCKc0PMMhDlrcysO3ufQ6Ab4MpEcQ==}
 
   '@vue/compiler-sfc@2.7.16':
     resolution: {integrity: sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==}
@@ -2722,8 +2728,14 @@ packages:
   '@vue/compiler-sfc@3.5.0':
     resolution: {integrity: sha512-B9DgLtrqok2GLuaFjLlSL15ZG3ZDBiitUH1ecex9guh/ZcA5MCdwuVE6nsfQxktuZY/QY0awJ35/ripIviCQTQ==}
 
+  '@vue/compiler-sfc@3.5.2':
+    resolution: {integrity: sha512-vErEtybSU290LbMW+ChYllI9tNJEdTW1oU+8cZWINZyjlWeTSa9YqDl4/pZJSnozOI+HmcaC1Vz2eFKmXNSXZA==}
+
   '@vue/compiler-ssr@3.5.0':
     resolution: {integrity: sha512-E263QZmA1dqRd7c3u/sWTLRMpQOT0aZ8av/L9SoD/v/BVMZaWFHPUUBswS+bzrfvG2suJF8vSLKx6k6ba5SUdA==}
+
+  '@vue/compiler-ssr@3.5.2':
+    resolution: {integrity: sha512-vMtA4tQK/AM3UAYJsmouQzQpgG+h9TKiD5BV+Zt+ZyAMdicxzSEEFGWf/CykRnDpqj9fMfIHPhOezJVNxiXe2A==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -2759,19 +2771,25 @@ packages:
   '@vue/reactivity@3.5.0':
     resolution: {integrity: sha512-Ew3F5riP3B3ZDGjD3ZKb9uZylTTPSqt8hAf4sGbvbjrjDjrFb3Jm15Tk1/w7WwTE5GbQ2Qhwxx1moc9hr8A/OQ==}
 
-  '@vue/runtime-core@3.5.0':
-    resolution: {integrity: sha512-mQyW0F9FaNRdt8ghkAs+BMG3iQ7LGgWKOpkzUzR5AI5swPNydHGL5hvVTqFaeMzwecF1g0c86H4yFQsSxJhH1w==}
+  '@vue/reactivity@3.5.2':
+    resolution: {integrity: sha512-lJwWL5bNht+2vIwU/+lnGdH+FKFxzz6z8WkoIJityPLiasWU+HDUvEsC7gm3JFwbTf7Kk+Nr9kJMaPy0HXwwxQ==}
 
-  '@vue/runtime-dom@3.5.0':
-    resolution: {integrity: sha512-NQQXjpdXgyYVJ2M56FJ+lSJgZiecgQ2HhxhnQBN95FymXegRNY/N2htI7vOTwpP75pfxhIeYOJ8mE8sW8KAW6A==}
+  '@vue/runtime-core@3.5.2':
+    resolution: {integrity: sha512-oU+i9sJjGEMfEhlrJ7SZv7CdSIgUNyBHnWHa0SqU2RF48V3/ATajzpWq1/DkiVJ1mtx+cQFAMKs8s/3cB3YlLQ==}
 
-  '@vue/server-renderer@3.5.0':
-    resolution: {integrity: sha512-HyDIFUg+l7L4PKrEnJlCYWHUOlm6NxZhmSxIefZ5MTYjkIPfDfkwhX7hqxAQHfgIAE1uLMLQZwuNR/ozI0NhZg==}
+  '@vue/runtime-dom@3.5.2':
+    resolution: {integrity: sha512-2qvysn+oR0QnFKaWZxQ90iVpWAK/WPpYmODHCv24IDXjsBrdHbjLBj9s6YBdPaMuQhs0LNsmhsgZYZBkszLg6g==}
+
+  '@vue/server-renderer@3.5.2':
+    resolution: {integrity: sha512-3POhYCA8KfbmuDuUiNbMXnpdh9pwE4SvAqo7VvACjklLkf3AaMkY3TvV7APeEa/WQezrnL+E4X2ASpJsKeS4cQ==}
     peerDependencies:
-      vue: 3.5.0
+      vue: 3.5.2
 
   '@vue/shared@3.5.0':
     resolution: {integrity: sha512-m9IgiteBpCkFaMNwCOBkFksA7z8QiKc30ooRuoXWUFRDu0mGyNPlFHmbncF0/Kra1RlX8QrmBbRaIxVvikaR0Q==}
+
+  '@vue/shared@3.5.2':
+    resolution: {integrity: sha512-Ce89WNFBzcDca/AgFTxgX4/K4iAyF7oFIp8Z5aBbFBNbtpwnQr+5pZOoHndxnjE2h+YFcipVMzs9UL11XB6dwA==}
 
   '@vueuse/core@11.0.3':
     resolution: {integrity: sha512-RENlh64+SYA9XMExmmH1a3TPqeIuJBNNB/63GT35MZI+zpru3oMRUA6cEFr9HmGqEgUisurwGwnIieF6qu3aXw==}
@@ -5910,8 +5928,8 @@ packages:
     resolution: {integrity: sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==}
     deprecated: Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.
 
-  vue@3.5.0:
-    resolution: {integrity: sha512-1t70favYoFijwfWJ7g81aTd32obGaAnKYE9FNyMgnEzn3F4YncRi/kqAHHKloG0VXTD8vBYMhbgLKCA+Sk6QDw==}
+  vue@3.5.2:
+    resolution: {integrity: sha512-w1YB4lAwC9ByH6AnFY0JvZF+y70Usul9jDfKIKtM5xA97q/JPS5R7mqq0fhA6D2PQxYPZdgb5jzFKLyOga5pnw==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -6230,14 +6248,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vue@4.5.0(astro@4.15.2(@types/node@22.5.2)(less@4.2.0)(rollup@4.21.2)(terser@5.31.6)(typescript@5.6.1-rc))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))':
+  '@astrojs/vue@4.5.0(astro@4.15.2(@types/node@22.5.2)(less@4.2.0)(rollup@4.21.2)(terser@5.31.6)(typescript@5.6.1-rc))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
-      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+      '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
+      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-sfc': 3.5.0
       astro: 4.15.2(@types/node@22.5.2)(less@4.2.0)(rollup@4.21.2)(terser@5.31.6)(typescript@5.6.1-rc)
-      vite-plugin-vue-devtools: 7.3.9(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vite-plugin-vue-devtools: 7.3.9(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - rollup
@@ -7046,7 +7064,7 @@ snapshots:
       '@iconify-json/octicon': 1.2.0
       less: 4.2.0
       vitepress: 1.3.4(@algolia/client-search@4.24.0)(@types/node@22.5.2)(less@4.2.0)(postcss@8.4.44)(terser@5.31.6)(typescript@5.6.1-rc)
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
@@ -7535,14 +7553,14 @@ snapshots:
   '@shikijs/vitepress-twoslash@1.16.1(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(typescript@5.6.1-rc)':
     dependencies:
       '@shikijs/twoslash': 1.16.1(typescript@5.6.1-rc)
-      floating-vue: 5.2.2(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(vue@3.5.0(typescript@5.6.1-rc))
+      floating-vue: 5.2.2(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(vue@3.5.2(typescript@5.6.1-rc))
       mdast-util-from-markdown: 2.0.1
       mdast-util-gfm: 3.0.0
       mdast-util-to-hast: 13.2.0
       shiki: 1.16.1
       twoslash: 0.2.10(typescript@5.6.1-rc)
       twoslash-vue: 0.2.10(typescript@5.6.1-rc)
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
@@ -7990,13 +8008,13 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.25.2)
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.25.2)
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - supports-color
 
@@ -8018,15 +8036,15 @@ snapshots:
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
       vue: 2.7.16
 
-  '@vitejs/plugin-vue2@2.3.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vitejs/plugin-vue2@2.3.1(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
 
-  '@vitejs/plugin-vue@5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vitejs/plugin-vue@5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
 
   '@vitest/coverage-v8@2.0.5(vitest@2.0.5(@types/node@22.5.2)(@vitest/ui@2.0.5)(less@4.2.0)(terser@5.31.6))':
     dependencies:
@@ -8102,41 +8120,41 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.0.8
 
-  '@vue-macros/api@0.10.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/api@0.10.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@babel/types': 7.25.6
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       resolve.exports: 2.0.2
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/better-define@1.8.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/better-define@1.8.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/api': 0.10.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/api': 0.10.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/boolean-prop@0.4.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/boolean-prop@0.4.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-core': 3.5.0
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/chain-call@0.3.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/chain-call@0.3.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/common@1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/common@1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@babel/types': 7.25.6
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
@@ -8145,13 +8163,13 @@ snapshots:
       local-pkg: 0.5.0
       magic-string-ast: 0.6.2
     optionalDependencies:
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/config@0.2.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/config@0.2.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       make-synchronized: 0.2.9
       unconfig: 0.5.5
     transitivePeerDependencies:
@@ -8159,106 +8177,106 @@ snapshots:
       - supports-color
       - vue
 
-  '@vue-macros/define-emit@0.3.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/define-emit@0.3.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/api': 0.10.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/api': 0.10.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-models@1.2.9(@vueuse/core@11.0.3(vue@3.5.0(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/define-models@1.2.9(@vueuse/core@11.0.3(vue@3.5.2(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       ast-walker-scope: 0.6.2
       unplugin: 1.12.3
     optionalDependencies:
-      '@vueuse/core': 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
+      '@vueuse/core': 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/define-prop@0.4.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/define-prop@0.4.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/api': 0.10.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/api': 0.10.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-props-refs@1.2.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/define-props-refs@1.2.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-props@3.0.3(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/define-props@3.0.3(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/reactivity-transform': 1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/reactivity-transform': 1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-render@1.5.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/define-render@1.5.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/define-slots@1.1.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/define-slots@1.1.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
   '@vue-macros/devtools@0.3.2(typescript@5.6.1-rc)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))':
     dependencies:
       sirv: 2.0.4
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     optionalDependencies:
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
     transitivePeerDependencies:
       - typescript
 
-  '@vue-macros/export-expose@0.2.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/export-expose@0.2.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-sfc': 3.5.0
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/export-props@0.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/export-props@0.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/export-render@0.2.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/export-render@0.2.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-sfc': 3.5.0
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/hoist-static@1.5.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/hoist-static@1.5.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
@@ -8266,99 +8284,99 @@ snapshots:
 
   '@vue-macros/jsx-directive@0.8.19(rollup@4.21.2)(typescript@5.6.1-rc)':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
       - typescript
 
-  '@vue-macros/named-template@0.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/named-template@0.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-dom': 3.5.0
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@babel/parser': 7.25.6
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-core': 3.5.0
       '@vue/shared': 3.5.0
       magic-string: 0.30.11
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/script-lang@0.1.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/script-lang@0.1.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/setup-block@0.3.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/setup-block@0.3.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-dom': 3.5.0
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/setup-component@0.17.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/setup-component@0.17.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/setup-sfc@0.17.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/setup-sfc@0.17.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/short-bind@1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/short-bind@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-core': 3.5.0
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/short-emits@1.5.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/short-emits@1.5.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/short-vmodel@1.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/short-vmodel@1.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/compiler-core': 3.5.0
     transitivePeerDependencies:
       - rollup
       - vue
 
-  '@vue-macros/volar@0.27.4(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc)))(rollup@4.21.2)(typescript@5.6.1-rc)(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue-macros/volar@0.27.4(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc)))(rollup@4.21.2)(typescript@5.6.1-rc)(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue-macros/boolean-prop': 0.4.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/config': 0.2.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/define-props': 3.0.3(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/short-bind': 1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/short-vmodel': 1.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/boolean-prop': 0.4.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/config': 0.2.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/define-props': 3.0.3(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/short-bind': 1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/short-vmodel': 1.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/language-core': 2.0.29(typescript@5.6.1-rc)
       muggle-string: 0.4.1
     optionalDependencies:
@@ -8478,10 +8496,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.0
 
+  '@vue/compiler-core@3.5.2':
+    dependencies:
+      '@babel/parser': 7.25.6
+      '@vue/shared': 3.5.2
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.0
+
   '@vue/compiler-dom@3.5.0':
     dependencies:
       '@vue/compiler-core': 3.5.0
       '@vue/shared': 3.5.0
+
+  '@vue/compiler-dom@3.5.2':
+    dependencies:
+      '@vue/compiler-core': 3.5.2
+      '@vue/shared': 3.5.2
 
   '@vue/compiler-sfc@2.7.16':
     dependencies:
@@ -8503,10 +8534,27 @@ snapshots:
       postcss: 8.4.44
       source-map-js: 1.2.0
 
+  '@vue/compiler-sfc@3.5.2':
+    dependencies:
+      '@babel/parser': 7.25.6
+      '@vue/compiler-core': 3.5.2
+      '@vue/compiler-dom': 3.5.2
+      '@vue/compiler-ssr': 3.5.2
+      '@vue/shared': 3.5.2
+      estree-walker: 2.0.2
+      magic-string: 0.30.11
+      postcss: 8.4.44
+      source-map-js: 1.2.0
+
   '@vue/compiler-ssr@3.5.0':
     dependencies:
       '@vue/compiler-dom': 3.5.0
       '@vue/shared': 3.5.0
+
+  '@vue/compiler-ssr@3.5.2':
+    dependencies:
+      '@vue/compiler-dom': 3.5.2
+      '@vue/shared': 3.5.2
 
   '@vue/compiler-vue2@2.7.16':
     dependencies:
@@ -8528,7 +8576,7 @@ snapshots:
     transitivePeerDependencies:
       - vite
 
-  '@vue/devtools-core@7.3.9(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue/devtools-core@7.3.9(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@vue/devtools-kit': 7.3.9
       '@vue/devtools-shared': 7.3.9
@@ -8536,7 +8584,7 @@ snapshots:
       nanoid: 3.3.7
       pathe: 1.1.2
       vite-hot-client: 0.2.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - vite
 
@@ -8581,25 +8629,31 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.0
 
-  '@vue/runtime-core@3.5.0':
+  '@vue/reactivity@3.5.2':
     dependencies:
-      '@vue/reactivity': 3.5.0
-      '@vue/shared': 3.5.0
+      '@vue/shared': 3.5.2
 
-  '@vue/runtime-dom@3.5.0':
+  '@vue/runtime-core@3.5.2':
     dependencies:
-      '@vue/reactivity': 3.5.0
-      '@vue/runtime-core': 3.5.0
-      '@vue/shared': 3.5.0
+      '@vue/reactivity': 3.5.2
+      '@vue/shared': 3.5.2
+
+  '@vue/runtime-dom@3.5.2':
+    dependencies:
+      '@vue/reactivity': 3.5.2
+      '@vue/runtime-core': 3.5.2
+      '@vue/shared': 3.5.2
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.0(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vue/server-renderer@3.5.2(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.0
-      '@vue/shared': 3.5.0
-      vue: 3.5.0(typescript@5.6.1-rc)
+      '@vue/compiler-ssr': 3.5.2
+      '@vue/shared': 3.5.2
+      vue: 3.5.2(typescript@5.6.1-rc)
 
   '@vue/shared@3.5.0': {}
+
+  '@vue/shared@3.5.2': {}
 
   '@vueuse/core@11.0.3(vue@2.7.16)':
     dependencies:
@@ -8611,21 +8665,21 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@11.0.3(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vueuse/core@11.0.3(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 11.0.3
-      '@vueuse/shared': 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
-      vue-demi: 0.14.10(vue@3.5.0(typescript@5.6.1-rc))
+      '@vueuse/shared': 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
+      vue-demi: 0.14.10(vue@3.5.2(typescript@5.6.1-rc))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/integrations@11.0.3(focus-trap@7.5.4)(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vueuse/integrations@11.0.3(focus-trap@7.5.4)(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      '@vueuse/core': 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
-      '@vueuse/shared': 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
-      vue-demi: 0.14.10(vue@3.5.0(typescript@5.6.1-rc))
+      '@vueuse/core': 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
+      '@vueuse/shared': 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
+      vue-demi: 0.14.10(vue@3.5.2(typescript@5.6.1-rc))
     optionalDependencies:
       focus-trap: 7.5.4
     transitivePeerDependencies:
@@ -8641,9 +8695,9 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@11.0.3(vue@3.5.0(typescript@5.6.1-rc))':
+  '@vueuse/shared@11.0.3(vue@3.5.2(typescript@5.6.1-rc))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.0(typescript@5.6.1-rc))
+      vue-demi: 0.14.10(vue@3.5.2(typescript@5.6.1-rc))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -9712,11 +9766,11 @@ snapshots:
 
   flattie@1.1.1: {}
 
-  floating-vue@5.2.2(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(vue@3.5.0(typescript@5.6.1-rc)):
+  floating-vue@5.2.2(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(vue@3.5.2(typescript@5.6.1-rc)):
     dependencies:
       '@floating-ui/dom': 1.1.1
-      vue: 3.5.0(typescript@5.6.1-rc)
-      vue-resize: 2.0.0-alpha.1(vue@3.5.0(typescript@5.6.1-rc))
+      vue: 3.5.2(typescript@5.6.1-rc)
+      vue-resize: 2.0.0-alpha.1(vue@3.5.2(typescript@5.6.1-rc))
     optionalDependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.5)(rollup@4.21.2)
 
@@ -11998,49 +12052,49 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  unplugin-vue-define-options@1.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc)):
+  unplugin-vue-define-options@1.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc)):
     dependencies:
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       ast-walker-scope: 0.6.2
       unplugin: 1.12.3
     transitivePeerDependencies:
       - rollup
       - vue
 
-  unplugin-vue-macros@2.11.6(@rspack/core@1.0.1)(@vueuse/core@11.0.3(vue@3.5.0(typescript@5.6.1-rc)))(esbuild@0.23.1)(rolldown@0.13.0)(rollup@4.21.2)(typescript@5.6.1-rc)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.0(typescript@5.6.1-rc))(webpack@5.94.0(esbuild@0.23.1)):
+  unplugin-vue-macros@2.11.6(@rspack/core@1.0.1)(@vueuse/core@11.0.3(vue@3.5.2(typescript@5.6.1-rc)))(esbuild@0.23.1)(rolldown@0.13.0)(rollup@4.21.2)(typescript@5.6.1-rc)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.2(typescript@5.6.1-rc))(webpack@5.94.0(esbuild@0.23.1)):
     dependencies:
-      '@vue-macros/better-define': 1.8.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/boolean-prop': 0.4.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/chain-call': 0.3.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/config': 0.2.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/define-emit': 0.3.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/define-models': 1.2.9(@vueuse/core@11.0.3(vue@3.5.0(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/define-prop': 0.4.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/define-props': 3.0.3(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/define-props-refs': 1.2.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/define-render': 1.5.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/define-slots': 1.1.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/better-define': 1.8.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/boolean-prop': 0.4.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/chain-call': 0.3.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/config': 0.2.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/define-emit': 0.3.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/define-models': 1.2.9(@vueuse/core@11.0.3(vue@3.5.2(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/define-prop': 0.4.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/define-props': 3.0.3(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc)))(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/define-props-refs': 1.2.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/define-render': 1.5.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/define-slots': 1.1.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue-macros/devtools': 0.3.2(typescript@5.6.1-rc)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))
-      '@vue-macros/export-expose': 0.2.2(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/export-props': 0.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/export-render': 0.2.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/hoist-static': 1.5.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/export-expose': 0.2.2(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/export-props': 0.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/export-render': 0.2.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/hoist-static': 1.5.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
       '@vue-macros/jsx-directive': 0.8.19(rollup@4.21.2)(typescript@5.6.1-rc)
-      '@vue-macros/named-template': 0.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/reactivity-transform': 1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/script-lang': 0.1.4(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/setup-block': 0.3.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/setup-component': 0.17.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/setup-sfc': 0.17.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/short-bind': 1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/short-emits': 1.5.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/short-vmodel': 1.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue-macros/volar': 0.27.4(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc)))(rollup@4.21.2)(typescript@5.6.1-rc)(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue-macros/named-template': 0.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/reactivity-transform': 1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/script-lang': 0.1.4(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/setup-block': 0.3.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/setup-component': 0.17.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/setup-sfc': 0.17.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/short-bind': 1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/short-emits': 1.5.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/short-vmodel': 1.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue-macros/volar': 0.27.4(@vue-macros/reactivity-transform@1.0.3(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc)))(rollup@4.21.2)(typescript@5.6.1-rc)(vue-tsc@2.0.29(typescript@5.6.1-rc))(vue@3.5.2(typescript@5.6.1-rc))
       unplugin: 1.12.3
       unplugin-combine: 1.0.2(@rspack/core@1.0.1)(esbuild@0.23.1)(rolldown@0.13.0)(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(webpack@5.94.0(esbuild@0.23.1))
-      unplugin-vue-define-options: 1.4.9(rollup@4.21.2)(vue@3.5.0(typescript@5.6.1-rc))
-      vue: 3.5.0(typescript@5.6.1-rc)
+      unplugin-vue-define-options: 1.4.9(rollup@4.21.2)(vue@3.5.2(typescript@5.6.1-rc))
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vueuse/core'
@@ -12053,13 +12107,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  unplugin-vue@5.1.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)(vue@3.5.0(typescript@5.6.1-rc)):
+  unplugin-vue@5.1.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)(vue@3.5.2(typescript@5.6.1-rc)):
     dependencies:
       '@vue/reactivity': 3.5.0
       debug: 4.3.6
       unplugin: 1.12.3
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12196,9 +12250,9 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-vue-devtools@7.3.9(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc)):
+  vite-plugin-vue-devtools@7.3.9(@nuxt/kit@3.13.0(magicast@0.3.5)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc)):
     dependencies:
-      '@vue/devtools-core': 7.3.9(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+      '@vue/devtools-core': 7.3.9(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/devtools-kit': 7.3.9
       '@vue/devtools-shared': 7.3.9
       execa: 8.0.1
@@ -12257,17 +12311,17 @@ snapshots:
       '@shikijs/core': 1.16.1
       '@shikijs/transformers': 1.16.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.0(typescript@5.6.1-rc))
+      '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6))(vue@3.5.2(typescript@5.6.1-rc))
       '@vue/devtools-api': 7.3.9
       '@vue/shared': 3.5.0
-      '@vueuse/core': 11.0.3(vue@3.5.0(typescript@5.6.1-rc))
-      '@vueuse/integrations': 11.0.3(focus-trap@7.5.4)(vue@3.5.0(typescript@5.6.1-rc))
+      '@vueuse/core': 11.0.3(vue@3.5.2(typescript@5.6.1-rc))
+      '@vueuse/integrations': 11.0.3(focus-trap@7.5.4)(vue@3.5.2(typescript@5.6.1-rc))
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 7.1.0
       shiki: 1.16.1
       vite: 5.4.3(@types/node@22.5.2)(less@4.2.0)(terser@5.31.6)
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
     optionalDependencies:
       postcss: 8.4.44
     transitivePeerDependencies:
@@ -12338,9 +12392,9 @@ snapshots:
     dependencies:
       vue: 2.7.16
 
-  vue-demi@0.14.10(vue@3.5.0(typescript@5.6.1-rc)):
+  vue-demi@0.14.10(vue@3.5.2(typescript@5.6.1-rc)):
     dependencies:
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
 
   vue-eslint-parser@9.4.3(eslint@9.9.1(jiti@1.21.6)):
     dependencies:
@@ -12355,9 +12409,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-resize@2.0.0-alpha.1(vue@3.5.0(typescript@5.6.1-rc)):
+  vue-resize@2.0.0-alpha.1(vue@3.5.2(typescript@5.6.1-rc)):
     dependencies:
-      vue: 3.5.0(typescript@5.6.1-rc)
+      vue: 3.5.2(typescript@5.6.1-rc)
 
   vue-tsc@2.0.29(typescript@5.6.1-rc):
     dependencies:
@@ -12371,13 +12425,13 @@ snapshots:
       '@vue/compiler-sfc': 2.7.16
       csstype: 3.1.3
 
-  vue@3.5.0(typescript@5.6.1-rc):
+  vue@3.5.2(typescript@5.6.1-rc):
     dependencies:
-      '@vue/compiler-dom': 3.5.0
-      '@vue/compiler-sfc': 3.5.0
-      '@vue/runtime-dom': 3.5.0
-      '@vue/server-renderer': 3.5.0(vue@3.5.0(typescript@5.6.1-rc))
-      '@vue/shared': 3.5.0
+      '@vue/compiler-dom': 3.5.2
+      '@vue/compiler-sfc': 3.5.2
+      '@vue/runtime-dom': 3.5.2
+      '@vue/server-renderer': 3.5.2(vue@3.5.2(typescript@5.6.1-rc))
+      '@vue/shared': 3.5.2
     optionalDependencies:
       typescript: 5.6.1-rc
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,14 +1,14 @@
 # eslint yml/sort-keys: 'error'
 
 catalog:
-  '@vue/compiler-core': ^3.5.0
-  '@vue/compiler-dom': ^3.5.0
-  '@vue/compiler-sfc': ^3.5.0
+  '@vue/compiler-core': ^3.5.2
+  '@vue/compiler-dom': ^3.5.2
+  '@vue/compiler-sfc': ^3.5.2
   '@vue/language-core': 2.0.29
-  '@vue/reactivity': ^3.5.0
-  '@vue/runtime-core': ^3.5.0
-  '@vue/runtime-dom': ^3.5.0
-  '@vue/shared': ^3.5.0
+  '@vue/reactivity': ^3.5.2
+  '@vue/runtime-core': ^3.5.2
+  '@vue/runtime-dom': ^3.5.2
+  '@vue/shared': ^3.5.2
   typescript: 5.6.1-rc
   unplugin: ^1.12.3
   vite: ^5.4.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalog:
   typescript: 5.6.1-rc
   unplugin: ^1.12.3
   vite: ^5.4.3
-  vue: ^3.5.0
+  vue: ^3.5.2
   vue-tsc: 2.0.29
 packages:
   - packages/*


### PR DESCRIPTION
To make ecosystem-ci pass: https://github.com/vuejs/ecosystem-ci/actions/runs/10702172980/job/29669763309

Edit: I realized this also need to bump Vue to 3.5.2 after it's released.