### PR TITLE
fix(volar/jsx-directive): incorrect transformation of intrinsic attributes

### DIFF
--- a/.changeset/two-poems-jump.md
+++ b/.changeset/two-poems-jump.md
@@ -1,0 +1,6 @@
+---
+"@vue-macros/volar": patch
+---
+
+prevent convert kebab-case prop to camel-case prop for jsx-directive
+  

--- a/packages/volar/src/jsx-directive/index.ts
+++ b/packages/volar/src/jsx-directive/index.ts
@@ -73,7 +73,7 @@ export function transformJsxDirective(options: TransformOptions): void {
         ctxNodeSet.add(node)
       } else if (/^on[A-Z]\S*_\S+/.test(attributeName)) {
         vOnWithModifiers.push({ node, attribute })
-      } else if (/^(?!v-|on[A-Z])\S+[_|-]\S+/.test(attributeName)) {
+      } else if (/^(?!v-|on[A-Z])\S+_\S+/.test(attributeName)) {
         vBindNodes.push({ node, attribute })
       } else if (attributeName === 'ref') {
         refNodes.push({ node, attribute })

--- a/packages/volar/src/jsx-directive/v-bind.ts
+++ b/packages/volar/src/jsx-directive/v-bind.ts
@@ -1,4 +1,3 @@
-import { allCodeFeatures, type Code } from '@vue/language-core'
 import { replaceSourceRange } from 'muggle-string'
 import { getStart, getText } from '../common'
 import type { JsxDirective, TransformOptions } from './index'

--- a/packages/volar/src/jsx-directive/v-bind.ts
+++ b/packages/volar/src/jsx-directive/v-bind.ts
@@ -18,6 +18,7 @@ export function transformVBind(
 
     if (
       attributeName.includes('-') &&
+      attributeName.includes('_') &&
       attribute.initializer &&
       !ts.isStringLiteral(attribute.initializer)
     ) {

--- a/packages/volar/src/jsx-directive/v-bind.ts
+++ b/packages/volar/src/jsx-directive/v-bind.ts
@@ -9,34 +9,15 @@ export function transformVBind(
 ): void {
   if (nodes.length === 0) return
 
-  const { codes, ts, source } = options
+  const { codes, source } = options
 
   for (const { attribute } of nodes) {
     const attributeName = getText(attribute.name, options)
     const start = getStart(attribute.name, options)
     const end = attribute.name.end
 
-    if (
-      attributeName.includes('-') &&
-      attributeName.includes('_') &&
-      attribute.initializer &&
-      !ts.isStringLiteral(attribute.initializer)
-    ) {
-      replaceSourceRange(
-        codes,
-        source,
-        start,
-        end,
-        ...(attributeName
-          .split('_')[0]
-          .split('-')
-          .map((code, index, codes) => [
-            index ? code.at(0)?.toUpperCase() + code.slice(1) : code,
-            source,
-            start + (index && codes[index - 1].length + 1),
-            allCodeFeatures,
-          ]) as Code[]),
-      )
+    if (attributeName.includes('_')) {
+      replaceSourceRange(codes, source, start + attributeName.indexOf('_'), end)
     }
   }
 }


### PR DESCRIPTION
Vue components can accept intrinsic attributes such as `aria-*` or `data-*`. The current implementation transforms all attributes with a `-` character. We should ignore any attributes for v-bind if they don't contain `_` as the purpose of the transformation is to support modifiers.

![Screenshot 2024-09-09 at 09 38 53](https://github.com/user-attachments/assets/fb56f463-cbe5-43ab-a71e-018a9c61b7cd)
