### PR TITLE
fix(volar): use configFilePath instead of pathsBasePath

### DIFF
--- a/.changeset/silent-spies-bathe.md
+++ b/.changeset/silent-spies-bathe.md
@@ -1,0 +1,6 @@
+---
+"@vue-macros/volar": patch
+---
+
+use configFilePath instead of pathsBasePath
+  

--- a/packages/volar/src/common.ts
+++ b/packages/volar/src/common.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import {
   resolveOptions,
   type FeatureName,
@@ -84,7 +85,7 @@ export function getVolarOptions<K extends keyof OptionsResolved>(
   context: PluginContext,
   key: K,
 ): OptionsResolved[K] {
-  const root = context.compilerOptions.pathsBasePath as string
+  const root = path.dirname(context.compilerOptions.configFilePath as string)
 
   let resolved: OptionsResolved | undefined
   if (!resolvedOptions.has(root)) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
The pathsBasePath will be undefined when paths unset in tsconfig.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
