### PR TITLE
feat(docs): enhance `code block` readability

### DIFF
--- a/docs/features/boolean-prop.md
+++ b/docs/features/boolean-prop.md
@@ -61,8 +61,7 @@ defineProps<{
 
 ## Volar Configuration
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/features/export-expose.md
+++ b/docs/features/export-expose.md
@@ -217,8 +217,7 @@ export default a
 
 ## Volar Configuration
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/features/export-props.md
+++ b/docs/features/export-props.md
@@ -30,8 +30,7 @@ export const bar: number = 1 // with default value
 
 ## Volar Configuration
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/features/export-render.md
+++ b/docs/features/export-render.md
@@ -31,8 +31,7 @@ export default () => <div>ok</div>
 
 ## Volar Configuration
 
-```jsonc {4,8}
-// tsconfig.json
+```jsonc {3,7} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/features/jsx-directive.md
+++ b/docs/features/jsx-directive.md
@@ -213,8 +213,7 @@ Modifiers are special postfixes denoted by a `_`, which indicate that a directiv
 
 ## Volar Configuration
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/features/reactivity-transform.md
+++ b/docs/features/reactivity-transform.md
@@ -72,8 +72,7 @@ module.exports = {
 
 ### TypeScript Support
 
-```json
-// tsconfig.json
+```json [tsconfig.json]
 {
   "compilerOptions": {
     // ...
@@ -386,7 +385,7 @@ This also means the macros can work in any files where valid JS / TS are allowed
 
 Since the macros are available globally, their types need to be explicitly referenced (e.g. in a `env.d.ts` file):
 
-```ts
+```ts [env.d.ts]
 /// <reference types="unplugin-vue-macros/macros-global" />
 
 // or for standalone version:

--- a/docs/features/script-lang.md
+++ b/docs/features/script-lang.md
@@ -38,8 +38,7 @@ defineProps<{
 
 ## Volar Configuration
 
-```jsonc {4,6-8}
-// tsconfig.json
+```jsonc {3,5-7} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/features/short-bind.md
+++ b/docs/features/short-bind.md
@@ -45,8 +45,7 @@ const value = 'foo'
 
 ## Volar Configuration
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/guide/astro-integration.md
+++ b/docs/guide/astro-integration.md
@@ -20,8 +20,7 @@ pnpm add -D @vue-macros/astro
 
 ## Configuration
 
-```ts
-// astro.config.mjs
+```ts [astro.config.mjs]
 import Vue from '@astrojs/vue'
 import Macros from '@vue-macros/astro'
 import { defineConfig } from 'astro/config'

--- a/docs/guide/bundler-integration.md
+++ b/docs/guide/bundler-integration.md
@@ -157,9 +157,7 @@ module.exports = defineConfig({
 
 See the [Configurations](./configurations.md) for more details.
 
-```ts twoslash
-// vue-macros.config.ts
-
+```ts twoslash [vue-macros.config.ts]
 import { defineConfig } from 'unplugin-vue-macros'
 export default defineConfig({
   // options
@@ -196,8 +194,7 @@ export default defineConfig({
 
 For detailed configuration, please refer to the description of the specific macro.
 
-```jsonc
-// tsconfig.json
+```jsonc [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],
@@ -210,9 +207,7 @@ For detailed configuration, please refer to the description of the specific macr
 `exportExpose`, `exportProps`, and `exportRender` plugins cannot be used
 at the same time unless providing a scope.
 
-```ts twoslash
-// vue-macros.config.ts
-
+```ts twoslash [vue-macros.config.ts]
 import { defineConfig } from 'unplugin-vue-macros'
 export default defineConfig({
   exportExpose: {

--- a/docs/guide/configurations.md
+++ b/docs/guide/configurations.md
@@ -22,9 +22,7 @@ All features are enabled by default except the following.
 
 You can re-enable them by setting the option to `true`.
 
-```ts twoslash
-// vue-macros.config.[js,ts,json]
-
+```ts twoslash [vue-macros.config.(ts,js,json)]
 import { defineConfig } from 'unplugin-vue-macros'
 export default defineConfig({
   root: '/your-project-path',

--- a/docs/guide/eslint-integration.md
+++ b/docs/guide/eslint-integration.md
@@ -22,8 +22,7 @@ npm i -D @vue-macros/eslint-config
 
 ### Flat Configuration
 
-```js
-// eslint.config.js
+```js [eslint.config.js]
 import vueMacros from '@vue-macros/eslint-config'
 export default [
   vueMacros,
@@ -33,8 +32,7 @@ export default [
 
 ### Legacy Configuration
 
-```jsonc
-// .eslintrc
+```jsonc [.eslintrc]
 {
   "extends": [
     "@vue-macros/eslint-config",

--- a/docs/guide/nuxt-integration.md
+++ b/docs/guide/nuxt-integration.md
@@ -20,8 +20,7 @@ pnpm add -D @vue-macros/nuxt
 
 ## Configuration
 
-```ts
-// nuxt.config.ts
+```ts [nuxt.config.ts]
 export default {
   modules: [
     '@vue-macros/nuxt',

--- a/docs/macros/define-emit.md
+++ b/docs/macros/define-emit.md
@@ -66,8 +66,7 @@ increment('2') // TS type error
 
 ## Volar Configuration
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/macros/define-models.md
+++ b/docs/macros/define-models.md
@@ -114,8 +114,7 @@ emit('update:count', count + 1)
 
 ## Volar Configuration
 
-```jsonc {5,7-10}
-// tsconfig.json
+```jsonc {4,6-9} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "target": 3, // or 2.7 for Vue 2

--- a/docs/macros/define-options.md
+++ b/docs/macros/define-options.md
@@ -76,8 +76,7 @@ module.exports = {
 
 ### TypeScript Support
 
-```json
-// tsconfig.json
+```json [tsconfig.json]
 {
   "compilerOptions": {
     // ...
@@ -156,8 +155,7 @@ export default {
 
 ## Volar Configuration
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/macros/define-prop.md
+++ b/docs/macros/define-prop.md
@@ -175,8 +175,7 @@ const bar = $(defineProp(0, true))
 
 ### Volar Configuration
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/macros/define-props-refs.md
+++ b/docs/macros/define-props-refs.md
@@ -48,8 +48,7 @@ console.log(foo.value)
 
 ## Volar Configuration
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/macros/define-props.md
+++ b/docs/macros/define-props.md
@@ -35,8 +35,7 @@ const fooRef = $$(foo)
 
 ## Volar Configuration
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/macros/define-slots.md
+++ b/docs/macros/define-slots.md
@@ -41,8 +41,7 @@ defineSlots<{
 
 ## Volar Configuration
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/macros/setup-sfc.md
+++ b/docs/macros/setup-sfc.md
@@ -87,8 +87,7 @@ export default () => (
 
 ## Volar Configuration
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/macros/short-vmodel.md
+++ b/docs/macros/short-vmodel.md
@@ -64,8 +64,7 @@ interface Options {
 
 ## Volar Configuration
 
-```jsonc {4,6-8}
-// tsconfig.json
+```jsonc {3,5-7} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "unplugin-vue-macros": "npm:unplugin-vue-macros@^2.11.12",
     "vite-plugin-vue-devtools": "^7.4.5",
     "vitepress": "^1.3.4",
-    "vitepress-plugin-group-icons": "^1.1.0",
+    "vitepress-plugin-group-icons": "^1.2.1",
     "vue": "catalog:"
   }
 }

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       customIcon: {
         rspack: localIconLoader(import.meta.url, './assets/rspack.svg'),
         rsbuild: localIconLoader(import.meta.url, './assets/rsbuild.svg'),
+        'vue-macros': localIconLoader(import.meta.url, './public/logo.svg'),
       },
     }),
   ],

--- a/docs/volar/define-generic.md
+++ b/docs/volar/define-generic.md
@@ -37,8 +37,7 @@ defineProps<{
 
 ## Volar Configuration
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/volar/script-sfc.md
+++ b/docs/volar/script-sfc.md
@@ -25,8 +25,7 @@ export default ({ foo }: { foo: number }) => (
 
 ## Volar Configuration
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["@vue-macros/volar"],

--- a/docs/volar/setup-jsdoc.md
+++ b/docs/volar/setup-jsdoc.md
@@ -75,8 +75,7 @@ export default <div />
 
 ## Volar Configuration
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/features/boolean-prop.md
+++ b/docs/zh-CN/features/boolean-prop.md
@@ -61,8 +61,7 @@ defineProps<{
 
 ## Volar 配置
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/features/export-expose.md
+++ b/docs/zh-CN/features/export-expose.md
@@ -217,8 +217,7 @@ export default a
 
 ## Volar 配置
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/features/export-props.md
+++ b/docs/zh-CN/features/export-props.md
@@ -31,8 +31,7 @@ export const bar: number = 1 // 带有默认值
 
 ## Volar 配置
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/features/export-render.md
+++ b/docs/zh-CN/features/export-render.md
@@ -31,8 +31,7 @@ export default () => <div>ok</div>
 
 ## Volar 配置
 
-```jsonc {4,8}
-// tsconfig.json
+```jsonc {3,7} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/features/jsx-directive.md
+++ b/docs/zh-CN/features/jsx-directive.md
@@ -213,8 +213,7 @@ export default () => (
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/features/reactivity-transform.md
+++ b/docs/zh-CN/features/reactivity-transform.md
@@ -72,8 +72,7 @@ module.exports = {
 
 ### TypeScript 支持
 
-```json
-// tsconfig.json
+```json [tsconfig.json]
 {
   "compilerOptions": {
     // ...
@@ -386,7 +385,7 @@ Vue 为这些宏函数都提供了类型声明 (全局可用)，因此类型推�
 
 因为这些宏函数都是全局可用的，它们的类型需要被显式地引用 (例如，在 `env.d.ts` 文件中)：
 
-```ts
+```ts [env.d.ts]
 /// <reference types="unplugin-vue-macros/macros-global" />
 
 // 或适用于独立版本：

--- a/docs/zh-CN/features/script-lang.md
+++ b/docs/zh-CN/features/script-lang.md
@@ -38,8 +38,7 @@ defineProps<{
 
 ## Volar Configuration
 
-```jsonc {4,6-8}
-// tsconfig.json
+```jsonc {3,5-7} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/features/short-bind.md
+++ b/docs/zh-CN/features/short-bind.md
@@ -45,8 +45,7 @@ const value = 'foo'
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/guide/astro-integration.md
+++ b/docs/zh-CN/guide/astro-integration.md
@@ -20,8 +20,7 @@ pnpm add -D @vue-macros/astro
 
 ## 配置
 
-```ts
-// astro.config.mjs
+```ts [astro.config.mjs]
 import Vue from '@astrojs/vue'
 import Macros from '@vue-macros/astro'
 import { defineConfig } from 'astro/config'

--- a/docs/zh-CN/guide/bundler-integration.md
+++ b/docs/zh-CN/guide/bundler-integration.md
@@ -157,9 +157,7 @@ module.exports = defineConfig({
 
 详情请参阅 [配置](./configurations.md)。
 
-```ts twoslash
-// vue-macros.config.ts
-
+```ts twoslash [vue-macros.config.ts]
 import { defineConfig } from 'unplugin-vue-macros'
 export default defineConfig({
   // 选项
@@ -196,8 +194,7 @@ export default defineConfig({
 
 详细配置请参阅具体宏的描述。
 
-```jsonc
-// tsconfig.json
+```jsonc [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],
@@ -209,9 +206,7 @@ export default defineConfig({
 
 `exportExpose`、`exportProps` 和 `exportRender` 插件不能同时使用，除非提供作用域。
 
-```ts twoslash
-// vue-macros.config.ts
-
+```ts twoslash [vue-macros.config.ts]
 import { defineConfig } from 'unplugin-vue-macros'
 export default defineConfig({
   exportExpose: {

--- a/docs/zh-CN/guide/configurations.md
+++ b/docs/zh-CN/guide/configurations.md
@@ -22,7 +22,7 @@
 
 你可以通过将选项设置为 `true` 来重新启用它们。
 
-```ts twoslash
+```ts twoslash [vue-macros.config.ts(js|ts|json)]
 // vue-macros.config.[js,ts,json]
 
 import { defineConfig } from 'unplugin-vue-macros'

--- a/docs/zh-CN/guide/eslint-integration.md
+++ b/docs/zh-CN/guide/eslint-integration.md
@@ -22,8 +22,7 @@ npm i -D @vue-macros/eslint-config
 
 ### Flat 风格配置
 
-```js
-// eslint.config.js
+```js [eslint.config.js]
 import vueMacros from '@vue-macros/eslint-config'
 export default [
   vueMacros,
@@ -33,8 +32,7 @@ export default [
 
 ### 传统风格配置
 
-```jsonc
-// .eslintrc
+```jsonc [.eslintrc]
 {
   "extends": [
     "@vue-macros/eslint-config",

--- a/docs/zh-CN/guide/nuxt-integration.md
+++ b/docs/zh-CN/guide/nuxt-integration.md
@@ -20,8 +20,7 @@ pnpm add -D @vue-macros/nuxt
 
 ## 配置
 
-```ts
-// nuxt.config.ts
+```ts [nuxt.config.ts]
 export default {
   modules: [
     '@vue-macros/nuxt',

--- a/docs/zh-CN/macros/define-emit.md
+++ b/docs/zh-CN/macros/define-emit.md
@@ -66,8 +66,7 @@ increment('2') // TS type error
 
 ## Volar 配置
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/macros/define-models.md
+++ b/docs/zh-CN/macros/define-models.md
@@ -114,8 +114,7 @@ emit('update:count', count + 1)
 
 ## Volar 配置
 
-```jsonc {5,7-10}
-// tsconfig.json
+```jsonc {4,6-9} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "target": 3, // 或 2.7 用于 Vue 2

--- a/docs/zh-CN/macros/define-options.md
+++ b/docs/zh-CN/macros/define-options.md
@@ -76,8 +76,7 @@ module.exports = {
 
 ### TypeScript 支持
 
-```json
-// tsconfig.json
+```json [tsconfig.json]
 {
   "compilerOptions": {
     // ...
@@ -156,8 +155,7 @@ export default {
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/macros/define-prop.md
+++ b/docs/zh-CN/macros/define-prop.md
@@ -160,8 +160,7 @@ const bar = $(defineProp(0, true))
 
 ## Volar 配置
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/macros/define-props-refs.md
+++ b/docs/zh-CN/macros/define-props-refs.md
@@ -48,8 +48,7 @@ console.log(foo.value)
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/macros/define-props.md
+++ b/docs/zh-CN/macros/define-props.md
@@ -35,8 +35,7 @@ const fooRef = $$(foo)
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["@vue-macros/volar/define-props"],

--- a/docs/zh-CN/macros/define-slots.md
+++ b/docs/zh-CN/macros/define-slots.md
@@ -41,8 +41,7 @@ defineSlots<{
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/macros/setup-sfc.md
+++ b/docs/zh-CN/macros/setup-sfc.md
@@ -87,8 +87,7 @@ export default () => (
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/macros/short-vmodel.md
+++ b/docs/zh-CN/macros/short-vmodel.md
@@ -64,8 +64,7 @@ interface Options {
 
 ## Volar 配置
 
-```jsonc {4,6-8}
-// tsconfig.json
+```jsonc {3,5-7} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/volar/define-generic.md
+++ b/docs/zh-CN/volar/define-generic.md
@@ -37,8 +37,7 @@ defineProps<{
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/docs/zh-CN/volar/script-sfc.md
+++ b/docs/zh-CN/volar/script-sfc.md
@@ -25,8 +25,7 @@ export default ({ foo }: { foo: number }) => (
 
 ## Volar 配置
 
-```jsonc {4,6}
-// tsconfig.json
+```jsonc {3,5} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["@vue-macros/volar"],

--- a/docs/zh-CN/volar/setup-jsdoc.md
+++ b/docs/zh-CN/volar/setup-jsdoc.md
@@ -75,8 +75,7 @@ export default <div />
 
 ## Volar 配置
 
-```jsonc {4}
-// tsconfig.json
+```jsonc {3} [tsconfig.json]
 {
   "vueCompilerOptions": {
     "plugins": ["unplugin-vue-macros/volar"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: ^1.3.4
         version: 1.3.4(@algolia/client-search@4.24.0)(@types/node@22.5.4)(less@4.2.0)(postcss@8.4.45)(terser@5.32.0)(typescript@5.6.2)
       vitepress-plugin-group-icons:
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.1
+        version: 1.2.1
       vue:
         specifier: 'catalog:'
         version: 3.5.4(typescript@5.6.2)
@@ -1870,8 +1870,8 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@iconify/utils@2.1.32':
-    resolution: {integrity: sha512-LeifFZPPKu28O3AEDpYJNdEbvS4/ojAPyIW+pF/vUpJTYnbTiXUHkCh0bwgFRzKvdpb8H4Fbfd/742++MF4fPQ==}
+  '@iconify/utils@2.1.33':
+    resolution: {integrity: sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -6158,8 +6158,8 @@ packages:
       vite:
         optional: true
 
-  vitepress-plugin-group-icons@1.1.0:
-    resolution: {integrity: sha512-hKf/imrMxa63kAXJlztsb8l6DZYBNZiVSZpJ15rNTeqAL1Hhbuf/DC87Q2r4b/mGKHUusEOI5ogt/jrJ8JoeUw==}
+  vitepress-plugin-group-icons@1.2.1:
+    resolution: {integrity: sha512-N1B/AgZ2OVYi8RTfxDIsklV2RU0ZW+Ozbul3M08akPVryPpDFkuirr/yB7uNUbyqEYW2b3OA3CbBQDzU4j26zg==}
 
   vitepress@1.3.4:
     resolution: {integrity: sha512-I1/F6OW1xl3kW4PaIMC6snxjWgf3qfziq2aqsDoFc/Gt41WbcRv++z8zjw8qGRIJ+I4bUW7ZcKFDHHN/jkH9DQ==}
@@ -7363,7 +7363,7 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@2.1.32':
+  '@iconify/utils@2.1.33':
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@antfu/utils': 0.7.10
@@ -8399,7 +8399,7 @@ snapshots:
 
   '@unocss/preset-icons@0.62.3':
     dependencies:
-      '@iconify/utils': 2.1.32
+      '@iconify/utils': 2.1.33
       '@unocss/core': 0.62.3
       ofetch: 1.3.4
     transitivePeerDependencies:
@@ -12860,11 +12860,11 @@ snapshots:
     optionalDependencies:
       vite: 5.4.4(@types/node@22.5.4)(less@4.2.0)(terser@5.32.0)
 
-  vitepress-plugin-group-icons@1.1.0:
+  vitepress-plugin-group-icons@1.2.1:
     dependencies:
       '@iconify-json/logos': 1.2.0
       '@iconify-json/vscode-icons': 1.2.1
-      '@iconify/utils': 2.1.32
+      '@iconify/utils': 2.1.33
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
### Description

There are new feature after [vitepress-plugin-group-icons@1.2.0](https://github.com/yuyinws/vitepress-plugin-group-icons/releases/tag/v1.2.0). It can add a title bar for `code block`, and display the icon and name on the title bar meanwhile.

#### Some screenshot:

<img width="747" alt="image" src="https://github.com/user-attachments/assets/bf20bcb0-d3ac-4156-ac61-574ba0049d23">

<img width="747" alt="image" src="https://github.com/user-attachments/assets/24d0f581-b119-4ca4-b527-05fb754d7875">

<img width="738" alt="image" src="https://github.com/user-attachments/assets/53d581fe-ef45-4b94-88f0-0d373e0c4207">

<img width="789" alt="image" src="https://github.com/user-attachments/assets/36871c50-b9e7-4f2d-86e9-a4bf3f34058f">



### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
