### PR TITLE
fix(volar/jsx-directive): use object instead of any

### DIFF
--- a/.changeset/new-dodos-kiss.md
+++ b/.changeset/new-dodos-kiss.md
@@ -1,0 +1,6 @@
+---
+"@vue-macros/volar": patch
+---
+
+use object instead of any
+  

--- a/packages/volar/src/jsx-directive/ref.ts
+++ b/packages/volar/src/jsx-directive/ref.ts
@@ -32,7 +32,7 @@ export function transformRef(
           getStart(attribute.initializer.expression, options),
           allCodeFeatures,
         ],
-        `} satisfies { ref: (e: Parameters<typeof ${ctxMap.get(node)}.expose>[0]) => any }) as any}`,
+        `} satisfies { ref: (e: Parameters<typeof ${ctxMap.get(node)}.expose>[0]) => any }) as {}}`,
       )
     }
   }

--- a/playground/vue3/src/examples/jsx-ref/index.vue
+++ b/playground/vue3/src/examples/jsx-ref/index.vue
@@ -10,8 +10,6 @@ const Comp1 = defineComponent({
   },
 })
 
-const foo = ref(1)
-
 const comp = useRef()
 let comp1 = $(useRef())
 const comp2 = useRef()

--- a/playground/vue3/src/examples/jsx-ref/index.vue
+++ b/playground/vue3/src/examples/jsx-ref/index.vue
@@ -21,7 +21,7 @@ defineRender(
     <Comp ref={comp} foo={1 as const} />
     {expectTypeOf<[1 | null | undefined]>([comp.value?.foo])}
 
-    <Comp1 ref={(e) => (comp1 = e)} foo={foo.value} />
+    <Comp1 ref={(e) => (comp1 = e)} />
     {expectTypeOf<[number | null | undefined]>([comp1?.foo])}
 
     <a ref={comp2} />

--- a/playground/vue3/src/examples/jsx-ref/index.vue
+++ b/playground/vue3/src/examples/jsx-ref/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="tsx">
 import { expectTypeOf } from 'expect-type'
 import { useRef } from 'unplugin-vue-macros/runtime'
-import { defineComponent, ref } from 'vue'
+import { defineComponent } from 'vue'
 import Comp from './comp.vue'
 
 const Comp1 = defineComponent({


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

```tsx
<Comp
  {...{ref: ... } as any}
  foo={foo} // <= will be never expose error
/>
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
