### PR TITLE
fix(volar/jsx-directive): use props instead of emits for inferred required type in v-model

### DIFF
--- a/.changeset/big-comics-exercise.md
+++ b/.changeset/big-comics-exercise.md
@@ -1,0 +1,6 @@
+---
+"@vue-macros/volar": patch
+---
+
+use props instead of emits for inferred required type in v-model
+  

--- a/packages/volar/src/jsx-directive/v-model.ts
+++ b/packages/volar/src/jsx-directive/v-model.ts
@@ -178,9 +178,9 @@ type __VLS_PropsToEmits<T> = T extends object
           : never]: T[K]
       }
     : never
-type __VLS_GetModels<P, E = __VLS_PropsToEmits<P>> = E extends object
+type __VLS_GetModels<P, E = __VLS_PropsToEmits<P>> = P extends object
   ? {
-      [K in keyof E as K extends keyof P
+      [K in keyof P as K extends keyof E
         ? K
         : never]: K extends keyof P ? P[K] : never
     }


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
