### PR TITLE
fix(volar/jsx-directive): use getStart instead of node.getStart to prevent vue-tsc error

### DIFF
--- a/.changeset/chilly-toes-give.md
+++ b/.changeset/chilly-toes-give.md
@@ -1,0 +1,6 @@
+---
+"@vue-macros/volar": patch
+---
+
+use getStart instead of node.getStart to prevent vue-tsc error
+  

--- a/packages/volar/src/jsx-directive/custom-directive.ts
+++ b/packages/volar/src/jsx-directive/custom-directive.ts
@@ -41,7 +41,7 @@ function transform(
   if (directiveName.includes(':')) {
     ;[directiveName, arg] = directiveName.split(':')
   }
-  const start = attribute.getStart(ast)
+  const start = getStart(attribute, options)
   const offset = start + directiveName.length + 2
   replaceSourceRange(
     codes,


### PR DESCRIPTION
use getStart instead of node.getStart to prevent vue-tsc error

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
