### PR TITLE
fix(jsx-directive): use compiler-sfc instead of compiler-core to expose walkIdentifiers

### DIFF
--- a/.changeset/shiny-cobras-hope.md
+++ b/.changeset/shiny-cobras-hope.md
@@ -1,0 +1,6 @@
+---
+"@vue-macros/jsx-directive": patch
+---
+
+use compiler-sfc instead of compiler-core to expose walkIdentifiers
+  

--- a/packages/jsx-directive/package.json
+++ b/packages/jsx-directive/package.json
@@ -147,7 +147,7 @@
   },
   "dependencies": {
     "@vue-macros/common": "workspace:*",
-    "@vue/compiler-core": "catalog:",
+    "@vue/compiler-sfc": "catalog:",
     "unplugin": "catalog:",
     "vue": "catalog:"
   },

--- a/packages/jsx-directive/src/core/restructure/index.ts
+++ b/packages/jsx-directive/src/core/restructure/index.ts
@@ -6,7 +6,7 @@ import {
   walkAST,
   type MagicString,
 } from '@vue-macros/common'
-import { walkIdentifiers } from '@vue/compiler-core'
+import { walkIdentifiers } from '@vue/compiler-sfc'
 import { withDefaultsHelperId } from '../helper'
 import type {
   ArrowFunctionExpression,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,7 +714,7 @@ importers:
       '@vue-macros/common':
         specifier: workspace:*
         version: link:../common
-      '@vue/compiler-core':
+      '@vue/compiler-sfc':
         specifier: 'catalog:'
         version: 3.5.13
       unplugin:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

compiler-core's walkIdentifiers don't support browser, so use compiler-sfc instead.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
