### PR TITLE
fix(volar/jsx-directive): prevent missing types when v-slots are used with v-for

### DIFF
--- a/packages/volar/src/jsx-directive/index.ts
+++ b/packages/volar/src/jsx-directive/index.ts
@@ -51,6 +51,8 @@ export function transformJsxDirective(options: TransformOptions): void {
 
   const ctxNodeMap: CtxMap = new Map()
 
+  let hasVForAttribute = false
+
   function walkJsxDirective(
     node: import('typescript').Node,
     parent?: import('typescript').Node,
@@ -74,6 +76,7 @@ export function transformJsxDirective(options: TransformOptions): void {
         vIfAttribute = attribute
       } else if (attributeName === `${prefix}for`) {
         vForAttribute = attribute
+        hasVForAttribute = true
       } else if (slotRegex.test(attributeName)) {
         vSlotAttribute = attribute
       } else if (modelRegex.test(attributeName)) {
@@ -217,7 +220,7 @@ export function transformJsxDirective(options: TransformOptions): void {
   const ctxMap = resolveCtxMap(ctxNodeMap, options)
 
   transformVSlot(vSlotMap, ctxMap, options)
-  transformVFor(vForNodes, options)
+  transformVFor(vForNodes, options, hasVForAttribute)
   vIfMap.forEach((nodes) => transformVIf(nodes, options))
   transformVModel(vModelMap, ctxMap, options)
   transformVOn(vOnNodes, ctxMap, options)

--- a/packages/volar/src/jsx-directive/v-for.ts
+++ b/packages/volar/src/jsx-directive/v-for.ts
@@ -88,8 +88,9 @@ export function resolveVFor(
 export function transformVFor(
   nodes: JsxDirective[],
   options: TransformOptions,
+  hasVForAttribute: boolean,
 ): void {
-  if (!nodes.length) return
+  if (!nodes.length && !hasVForAttribute) return
   const { codes, source } = options
 
   nodes.forEach(({ attribute, node, parent }) => {

--- a/packages/volar/src/jsx-directive/v-slot.ts
+++ b/packages/volar/src/jsx-directive/v-slot.ts
@@ -123,7 +123,7 @@ export function transformVSlot(
         )
 
         if (vForAttribute) {
-          result.push('})),')
+          result.push('})) as any,')
         }
 
         if (vIfAttribute && vIfAttributeName) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
