### PR TITLE
fix: fix `llms.txt` generation

### DIFF
--- a/docs/.vitepress/config/index.ts
+++ b/docs/.vitepress/config/index.ts
@@ -3,6 +3,7 @@ import { transformerTwoslash } from '@shikijs/vitepress-twoslash'
 import ts from 'typescript'
 import { defineConfig } from 'vitepress'
 import { groupIconMdPlugin } from 'vitepress-plugin-group-icons'
+import llmstxt from 'vitepress-plugin-llms'
 import VueMacrosPlugin from 'vue-macros/volar'
 import { docsLink } from '../../../macros'
 import { getLocaleConfig } from './theme'
@@ -69,6 +70,13 @@ export default defineConfig({
             }),
           ]
         : []),
+    ],
+  },
+  vite: {
+    plugins: [
+      llmstxt({
+        ignoreFiles: ['interactive/**/*', 'zh-CN/**/*', 'index.md'],
+      }),
     ],
   },
 })

--- a/docs/.vitepress/config/index.ts
+++ b/docs/.vitepress/config/index.ts
@@ -3,7 +3,6 @@ import { transformerTwoslash } from '@shikijs/vitepress-twoslash'
 import ts from 'typescript'
 import { defineConfig } from 'vitepress'
 import { groupIconMdPlugin } from 'vitepress-plugin-group-icons'
-import llmstxt from 'vitepress-plugin-llms'
 import VueMacrosPlugin from 'vue-macros/volar'
 import { docsLink } from '../../../macros'
 import { getLocaleConfig } from './theme'
@@ -70,13 +69,6 @@ export default defineConfig({
             }),
           ]
         : []),
-    ],
-  },
-  vite: {
-    plugins: [
-      llmstxt({
-        ignoreFiles: ['interactive/**/*', 'zh-CN/**/*', 'index.md'],
-      }),
     ],
   },
 })

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -10,10 +10,14 @@ import {
   groupIconVitePlugin,
   localIconLoader,
 } from 'vitepress-plugin-group-icons'
+import llmstxt from 'vitepress-plugin-llms'
 import { githubLink } from '../macros/repo'
 
 export default defineConfig({
   plugins: [
+    llmstxt({
+      ignoreFiles: ['interactive/**/*', 'zh-CN/**/*', 'index.md'],
+    }),
     VueJsx(),
     Unocss(),
     Devtools(),

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -10,12 +10,10 @@ import {
   groupIconVitePlugin,
   localIconLoader,
 } from 'vitepress-plugin-group-icons'
-import llmstxt from 'vitepress-plugin-llms'
 import { githubLink } from '../macros/repo'
 
 export default defineConfig({
   plugins: [
-    llmstxt(),
     VueJsx(),
     Unocss(),
     Devtools(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,8 +271,8 @@ catalogs:
       specifier: ^1.3.8
       version: 1.3.8
     vitepress-plugin-llms:
-      specifier: ^0.0.8
-      version: 0.0.8
+      specifier: ^0.0.9
+      version: 0.0.9
     vitest:
       specifier: ^3.0.9
       version: 3.0.9
@@ -485,7 +485,7 @@ importers:
         version: 1.3.8
       vitepress-plugin-llms:
         specifier: 'catalog:'
-        version: 0.0.8
+        version: 0.0.9
       vue:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.2)
@@ -7526,8 +7526,8 @@ packages:
   vitepress-plugin-group-icons@1.3.8:
     resolution: {integrity: sha512-BIx1HgXEvbDeJX8NqVvthWHQqEW2slj1SkAWLMNoUR5IJq1dq6LmrURYCyznMJCB3/0g+YY89ifvQp3in1fX3g==}
 
-  vitepress-plugin-llms@0.0.8:
-    resolution: {integrity: sha512-xz4wb87TqAn75RbKwQs+w+63OToK7W57pmLKIEY849Izpzi/WvTI9T+rCDwabdhPFirI3LLT2P2nErsSrik0/A==}
+  vitepress-plugin-llms@0.0.9:
+    resolution: {integrity: sha512-d1bz0PC41PFVMyTDv4EvAS9/amDHbKzc0C5C+KJW+p19AG0luzSeQA0cfJ96lWvBdAEoSnsvsO8AXucyvVPyyQ==}
 
   vitepress@2.0.0-alpha.2:
     resolution: {integrity: sha512-w+1WCkd8ko8lDUh61OWo4dj5Y4VHYJvwmJ9/iOXoVlzxOfO5Hoio2H3OMOgNlCzq0E0rTp9UR5GPU120AnH2dg==}
@@ -15153,7 +15153,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress-plugin-llms@0.0.8:
+  vitepress-plugin-llms@0.0.9:
     dependencies:
       gray-matter: 4.0.3
       markdown-title: 1.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -122,7 +122,7 @@ catalog:
   vite-plugin-vue-devtools: ^7.7.2
   vitepress: ^2.0.0-alpha.2
   vitepress-plugin-group-icons: ^1.3.8
-  vitepress-plugin-llms: ^0.0.8
+  vitepress-plugin-llms: ^0.0.9
   webpack: ^5.98.0
 
 peerDependencyRules:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Thanks for using my plugin 🤝

But I noticed a problem in the commit https://github.com/vue-macros/vue-macros/commit/d25754ee06572d08fd1dfb6103affe5a4b229c40

@sxzz you added the plugin to the **Vite** configuration, but it needs to be added to the **VitePress** configuration (`.vitepress/config/index.ts`) for it to work correctly

I excluded the Chinese version of the documentation for LLMs (and why have LLM documentation in two languages ​​if you can leave only English?) and some extra files

Now the documentation is generated correctly and only in English