### PR TITLE
feat(nuxt): expose volar plugin

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -35,12 +35,17 @@
       "dev": "./src/index.ts",
       "default": "./dist/index.js"
     },
+    "./volar": {
+      "dev": "./src/volar.ts",
+      "default": "./dist/volar.js"
+    },
     "./*": "./*"
   },
   "publishConfig": {
     "access": "public",
     "exports": {
       ".": "./dist/index.js",
+      "./volar": "./dist/volar.js",
       "./*": "./*"
     },
     "tag": "next"

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -21,7 +21,7 @@ const module: NuxtModule<Options> = defineNuxtModule<Options>({
     const vueCompilerOptions =
       (nuxt.options.typescript.tsConfig.vueCompilerOptions ||= {})
     vueCompilerOptions.plugins ||= []
-    vueCompilerOptions.plugins.push('vue-macros/volar')
+    vueCompilerOptions.plugins.push('@vue-macros/nuxt/volar')
 
     nuxt.hook(
       'vite:configResolved',

--- a/packages/nuxt/src/volar.ts
+++ b/packages/nuxt/src/volar.ts
@@ -1,0 +1,1 @@
+export * from 'vue-macros/volar'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Issues #948 and #956: The Volar plugin does not work when only `@vue-macros/nuxt` is installed.

Since Volar plugin config of  `.nuxt/tsconfig.json` is `vue-macros/volar`, `@vue/language-tools` does not read it's path correctly when vue-macros is not installed.
```json
{
  "vueCompilerOptions": {
    "plugins": [
      "vue-macros/volar"
    ]
  }
}
```

So i expose a Volar plugin for package.json, and use `@vue-macros/nuxt/volar` instead `vue-macros/volar` to resolve it.

```json
{
  "vueCompilerOptions": {
    "plugins": [
      "@vue-macros/nuxt/volar"
    ]
  }
}
```


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
