### PR TITLE
refactor(volar):  upgrade ts-macro to 0.2.7

### DIFF
--- a/packages/volar/src/common.ts
+++ b/packages/volar/src/common.ts
@@ -7,7 +7,7 @@ import {
 } from '@vue-macros/config'
 import { replace, replaceAll, type Code } from 'ts-macro'
 import type { SFCScriptBlock } from '@vue-macros/common'
-import type { Sfc, VueLanguagePlugin } from '@vue/language-core'
+import type { VueLanguagePlugin } from '@vue/language-core'
 
 export const REGEX_DEFINE_COMPONENT: RegExp =
   /(?<=(?:__VLS_|\(await import\(\S+\)\)\.)defineComponent\(\{\n)/g
@@ -137,38 +137,6 @@ export function getVolarOptions<K extends keyof OptionsResolved>(
   }
 
   return (resolved || resolvedOptions.get(root)!)[key]
-}
-
-export interface VolarContext {
-  ts: typeof import('typescript')
-  ast?: import('typescript').SourceFile
-  sfc?: Sfc
-  source?: 'script' | 'scriptSetup'
-}
-
-export function getStart(
-  node:
-    | import('typescript').Node
-    | import('typescript').NodeArray<import('typescript').Node>,
-  { ts, ast, sfc, source = 'scriptSetup' }: VolarContext,
-): number {
-  ast = ast || sfc?.[source]?.ast
-  return (ts as any).getTokenPosOfNode(node, ast)
-}
-
-export function getText(
-  node: import('typescript').Node,
-  context: VolarContext,
-): string {
-  let { sfc, ast, source = 'scriptSetup' } = context
-  ast = ast || sfc?.[source]?.ast
-  return ast!.text.slice(getStart(node, context), node.end)
-}
-
-export function isJsxExpression(
-  node?: import('typescript').Node,
-): node is import('typescript').JsxExpression {
-  return node?.kind === 294
 }
 
 export function patchSFC(block: SFCScriptBlock | null, offset: number): void {

--- a/packages/volar/src/define-generic.ts
+++ b/packages/volar/src/define-generic.ts
@@ -1,6 +1,7 @@
 import { createFilter } from '@vue-macros/common'
 import { replace, replaceSourceRange } from 'muggle-string'
-import { getText, type VueMacrosPlugin } from './common'
+import { getText } from 'ts-macro'
+import type { VueMacrosPlugin } from './common'
 import type { Code, Sfc } from '@vue/language-core'
 
 function getDefineGenerics(
@@ -9,8 +10,8 @@ function getDefineGenerics(
   codes: Code[],
 ) {
   const result: string[] = []
-  const sourceFile = sfc.scriptSetup!.ast
-  ts.forEachChild(sourceFile, (node) => {
+  const ast = sfc.scriptSetup!.ast
+  ts.forEachChild(ast, (node) => {
     if (
       ts.isTypeAliasDeclaration(node) &&
       ts.isTypeReferenceNode(node.type) &&
@@ -35,10 +36,10 @@ function getDefineGenerics(
       }
 
       const typeArgument = node.type.typeArguments?.[0]
-        ? ` extends ${getText(node.type.typeArguments[0], { ts, sfc })}`
+        ? ` extends ${getText(node.type.typeArguments[0], ast, ts)}`
         : ''
       const defaultType = node.type.typeArguments?.[1]
-        ? ` = ${getText(node.type.typeArguments[1], { ts, sfc })}`
+        ? ` = ${getText(node.type.typeArguments[1], ast, ts)}`
         : ''
       result.push(`${node.name.escapedText}${typeArgument}${defaultType}`)
     }

--- a/packages/volar/src/define-models.ts
+++ b/packages/volar/src/define-models.ts
@@ -3,7 +3,8 @@ import {
   DEFINE_MODELS,
   DEFINE_MODELS_DOLLAR,
 } from '@vue-macros/common'
-import { addEmits, addProps, getText, type VueMacrosPlugin } from './common'
+import { getText } from 'ts-macro'
+import { addEmits, addProps, type VueMacrosPlugin } from './common'
 import type { Code, Sfc } from '@vue/language-core'
 
 function transformDefineModels(options: {
@@ -13,7 +14,8 @@ function transformDefineModels(options: {
   version: number
   ts: typeof import('typescript')
 }) {
-  const { codes, typeArg, version, ts } = options
+  const { codes, typeArg, version, ts, sfc } = options
+  const ast = sfc.scriptSetup!.ast
 
   const propStrings: Code[] = []
   const emitStrings: Code[] = []
@@ -21,8 +23,8 @@ function transformDefineModels(options: {
   if (ts.isTypeLiteralNode(typeArg) && typeArg.members) {
     for (const member of typeArg.members) {
       if (ts.isPropertySignature(member) && member.type) {
-        const type = getText(member.type, options)
-        const name = getText(member.name, options)
+        const type = getText(member.type, ast, ts)
+        const name = getText(member.name, ast, ts)
         emitStrings.push(`'update:${name}': [${name}: ${type}]`)
 
         propStrings.push(`${name}${member.questionToken ? '?' : ''}: ${type}`)

--- a/packages/volar/src/define-prop.ts
+++ b/packages/volar/src/define-prop.ts
@@ -3,7 +3,8 @@ import {
   DEFINE_PROP,
   DEFINE_PROP_DOLLAR,
 } from '@vue-macros/common'
-import { addProps, getText, type VueMacrosPlugin } from './common'
+import { getText } from 'ts-macro'
+import { addProps, type VueMacrosPlugin } from './common'
 import type { Code, Sfc } from '@vue/language-core'
 
 interface DefineProp {
@@ -137,17 +138,17 @@ function getDefineProp(
     ) {
       if (edition === 'kevinEdition') {
         const type = node.typeArguments?.length
-          ? getText(node.typeArguments[0], { ts, sfc })
+          ? getText(node.typeArguments[0], ast, ts)
           : undefined
         const name =
           node.arguments[0] && ts.isStringLiteral(node.arguments[0])
             ? node.arguments[0].text
             : ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)
-              ? getText(parent.name, { ts, sfc })
+              ? getText(parent.name, ast, ts)
               : undefined
         const prop =
           ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)
-            ? getText(parent.name, { ts, sfc })
+            ? getText(parent.name, ast, ts)
             : undefined
         const optionArg =
           node.arguments[0] && ts.isObjectLiteralExpression(node.arguments[0])
@@ -166,16 +167,16 @@ function getDefineProp(
               ts.isIdentifier(property.name)
             ) {
               if (
-                getText(property.name, { ts, sfc }) === 'required' &&
+                getText(property.name, ast, ts) === 'required' &&
                 property.initializer.kind === ts.SyntaxKind.TrueKeyword
               )
                 required = true
 
               if (
                 ts.isIdentifier(property.name) &&
-                getText(property.name, { ts, sfc }) === 'default'
+                getText(property.name, ast, ts) === 'default'
               )
-                defaultValue = getText(property.initializer, { ts, sfc })
+                defaultValue = getText(property.initializer, ast, ts)
             }
           }
         }
@@ -195,17 +196,17 @@ function getDefineProp(
         ts.isVariableDeclaration(parent)
       ) {
         const name = ts.isIdentifier(parent.name)
-          ? getText(parent.name, { ts, sfc })
+          ? getText(parent.name, ast, ts)
           : undefined
         defineProps.push({
           name,
           prop: name,
           defaultValue:
             node.arguments.length > 0
-              ? getText(node.arguments[0], { ts, sfc })
+              ? getText(node.arguments[0], ast, ts)
               : undefined,
           type: node.typeArguments?.length
-            ? getText(node.typeArguments[0], { ts, sfc })
+            ? getText(node.typeArguments[0], ast, ts)
             : undefined,
           required:
             node.arguments.length >= 2 &&

--- a/packages/volar/src/export-props.ts
+++ b/packages/volar/src/export-props.ts
@@ -1,6 +1,7 @@
 import { createFilter } from '@vue-macros/common'
 import { replaceSourceRange } from 'muggle-string'
-import { addProps, getStart, type VueMacrosPlugin } from './common'
+import { getStart } from 'ts-macro'
+import { addProps, type VueMacrosPlugin } from './common'
 import type { Code, Sfc } from '@vue/language-core'
 
 function transform(options: {
@@ -10,6 +11,7 @@ function transform(options: {
   version: number
 }) {
   const { codes, sfc, ts, version } = options
+  const ast = sfc.scriptSetup!.ast
 
   const props: Record<string, boolean> = Object.create(null)
   let changed = false
@@ -23,7 +25,7 @@ function transform(options: {
     replaceSourceRange(
       codes,
       'scriptSetup',
-      getStart(exportModifier, options),
+      getStart(exportModifier, ast, ts),
       exportModifier.end,
     )
     changed = true

--- a/packages/volar/src/export-render.ts
+++ b/packages/volar/src/export-render.ts
@@ -1,6 +1,7 @@
 import { createFilter } from '@vue-macros/common'
 import { replaceSourceRange } from 'muggle-string'
-import { getStart, type VueMacrosPlugin } from './common'
+import { getStart } from 'ts-macro'
+import type { VueMacrosPlugin } from './common'
 import type { Code, Sfc } from '@vue/language-core'
 
 function transform(options: {
@@ -9,6 +10,7 @@ function transform(options: {
   ts: typeof import('typescript')
 }) {
   const { codes, sfc, ts } = options
+  const ast = sfc.scriptSetup!.ast
 
   for (const stmt of sfc.scriptSetup!.ast.statements) {
     if (!ts.isExportAssignment(stmt)) continue
@@ -16,8 +18,8 @@ function transform(options: {
     replaceSourceRange(
       codes,
       'scriptSetup',
-      getStart(stmt, options),
-      getStart(stmt.expression, options),
+      getStart(stmt, ast, ts),
+      getStart(stmt.expression, ast, ts),
       'defineRender(',
     )
     replaceSourceRange(

--- a/packages/volar/src/jsx-directive/custom-directive.ts
+++ b/packages/volar/src/jsx-directive/custom-directive.ts
@@ -1,5 +1,4 @@
 import { allCodeFeatures, type Code } from 'ts-macro'
-import { getStart, getText } from '../common'
 import type { TransformOptions } from '.'
 
 export function transformCustomDirective(
@@ -28,7 +27,7 @@ function transform(
 ) {
   const { codes, ts, ast } = options
 
-  const attributeName = getText(attribute.name, options)
+  const attributeName = attribute.name.getText(ast)
   let directiveName = attributeName.split(/\s/)[0].split('v-')[1]
   let modifiers: string[] = []
   if (directiveName.includes('_')) {
@@ -40,7 +39,7 @@ function transform(
   if (directiveName.includes(':')) {
     ;[directiveName, arg] = directiveName.split(':')
   }
-  const start = getStart(attribute, options)
+  const start = attribute.getStart(ast)
   const offset = start + directiveName.length + 2
   codes.replaceRange(
     start,
@@ -53,9 +52,9 @@ function transform(
     attribute.initializer
       ? [
           ts.isStringLiteral(attribute.initializer)
-            ? getText(attribute.initializer, options)
-            : getText(attribute.initializer, options).slice(1, -1),
-          getStart(attribute.initializer, options) +
+            ? attribute.initializer.getText(ast)
+            : attribute.initializer.getText(ast).slice(1, -1),
+          attribute.initializer.getStart(ast) +
             (ts.isStringLiteral(attribute.initializer) ? 0 : 1),
         ]
       : '{} as any',
@@ -75,7 +74,7 @@ function transform(
             modify ? '' : `'`,
             [
               modify,
-              getStart(attribute, options) +
+              attribute.getStart(ast) +
                 (attributeName.indexOf('_') + 1) +
                 (index ? modifiers.slice(0, index).join('').length + index : 0),
             ],

--- a/packages/volar/src/jsx-directive/ref.ts
+++ b/packages/volar/src/jsx-directive/ref.ts
@@ -1,4 +1,3 @@
-import { getStart, getText, isJsxExpression } from '../common'
 import type { JsxDirective, TransformOptions } from './index'
 
 export function transformRef(
@@ -6,25 +5,25 @@ export function transformRef(
   ctxMap: Map<JsxDirective['node'], string>,
   options: TransformOptions,
 ): void {
-  const { codes, ts } = options
+  const { codes, ts, ast } = options
 
   for (const { node, attribute } of nodes) {
     if (
       attribute.initializer &&
-      isJsxExpression(attribute.initializer) &&
+      ts.isJsxExpression(attribute.initializer) &&
       attribute.initializer.expression &&
       (ts.isFunctionExpression(attribute.initializer.expression) ||
         ts.isArrowFunction(attribute.initializer.expression))
     ) {
       codes.replaceRange(
-        getStart(attribute, options),
+        attribute.getStart(ast),
         attribute.end,
         '{...({ ',
-        ['ref', getStart(attribute.name, options)],
+        ['ref', attribute.name.getStart(ast)],
         ': ',
         [
-          getText(attribute.initializer.expression, options),
-          getStart(attribute.initializer.expression, options),
+          attribute.initializer.expression.getText(ast),
+          attribute.initializer.expression.getStart(ast),
         ],
         `} satisfies { ref: (e: Parameters<typeof ${ctxMap.get(node)}.expose>[0]) => any }) as {}}`,
       )

--- a/packages/volar/src/jsx-directive/v-bind.ts
+++ b/packages/volar/src/jsx-directive/v-bind.ts
@@ -1,4 +1,3 @@
-import { getStart, getText } from '../common'
 import type { JsxDirective, TransformOptions } from './index'
 
 export function transformVBind(
@@ -7,11 +6,11 @@ export function transformVBind(
 ): void {
   if (nodes.length === 0) return
 
-  const { codes } = options
+  const { codes, ast } = options
 
   for (const { attribute } of nodes) {
-    const attributeName = getText(attribute.name, options)
-    const start = getStart(attribute.name, options)
+    const attributeName = attribute.name.getText(ast)
+    const start = attribute.name.getStart(ast)
     const end = attribute.name.end
 
     if (attributeName.includes('_')) {

--- a/packages/volar/src/jsx-directive/v-if.ts
+++ b/packages/volar/src/jsx-directive/v-if.ts
@@ -17,7 +17,7 @@ export function transformVIf(
       ts.isJsxExpression(attribute.initializer) &&
       attribute.initializer.expression
     ) {
-      const hasScope = parent && attribute.name.escapedText === `${prefix}if`
+      const hasScope = parent && attribute.name.text === `${prefix}if`
       codes.replaceRange(
         node.getStart(ast),
         node.getStart(ast),
@@ -32,14 +32,14 @@ export function transformVIf(
       const nextAttribute = nodes[index + 1]?.attribute
       const nextNodeHasElse =
         nextAttribute && ts.isIdentifier(nextAttribute.name)
-          ? String(nextAttribute.name.escapedText).startsWith(`${prefix}else`)
+          ? String(nextAttribute.name.text).startsWith(`${prefix}else`)
           : false
       codes.replaceRange(
         node.end,
         node.end,
         nextNodeHasElse ? ' : ' : ` : null${parent ? '}' : ''}`,
       )
-    } else if (attribute.name.escapedText === `${prefix}else`) {
+    } else if (attribute.name.text === `${prefix}else`) {
       codes.replaceRange(node.end, node.end, parent ? '}' : '')
     }
 

--- a/packages/volar/src/jsx-directive/v-if.ts
+++ b/packages/volar/src/jsx-directive/v-if.ts
@@ -1,30 +1,30 @@
-import { getStart, getText, isJsxExpression } from '../common'
 import type { JsxDirective, TransformOptions } from './index'
 
 export function transformVIf(
   nodes: JsxDirective[],
   options: TransformOptions,
 ): void {
-  const { codes, ts, prefix } = options
+  const { codes, ts, prefix, ast } = options
 
   nodes.forEach(({ node, attribute, parent }, index) => {
     if (!ts.isIdentifier(attribute.name)) return
 
     if (
       [`${prefix}if`, `${prefix}else-if`].includes(
-        getText(attribute.name, options),
+        attribute.name.getText(ast),
       ) &&
-      isJsxExpression(attribute.initializer) &&
+      attribute.initializer &&
+      ts.isJsxExpression(attribute.initializer) &&
       attribute.initializer.expression
     ) {
       const hasScope = parent && attribute.name.escapedText === `${prefix}if`
       codes.replaceRange(
-        getStart(node, options),
-        getStart(node, options),
+        node.getStart(ast),
+        node.getStart(ast),
         `${hasScope ? '{' : ''}(`,
         [
-          getText(attribute.initializer.expression, options),
-          getStart(attribute.initializer.expression, options),
+          attribute.initializer.expression.getText(ast),
+          attribute.initializer.expression.getStart(ast),
         ],
         ') ? ',
       )
@@ -43,6 +43,6 @@ export function transformVIf(
       codes.replaceRange(node.end, node.end, parent ? '}' : '')
     }
 
-    codes.replaceRange(getStart(attribute, options), attribute.end)
+    codes.replaceRange(attribute.getStart(ast), attribute.end)
   })
 }

--- a/packages/volar/src/jsx-directive/v-on.ts
+++ b/packages/volar/src/jsx-directive/v-on.ts
@@ -1,4 +1,3 @@
-import { getStart, getText, isJsxExpression } from '../common'
 import type { JsxDirective, TransformOptions } from './index'
 
 export function transformVOn(
@@ -7,14 +6,10 @@ export function transformVOn(
   options: TransformOptions,
 ): void {
   if (nodes.length === 0) return
-  const { codes } = options
+  const { codes, ast } = options
 
   for (const { node, attribute } of nodes) {
-    codes.replaceRange(
-      getStart(attribute, options),
-      attribute.name.end + 2,
-      '{...',
-    )
+    codes.replaceRange(attribute.getStart(ast), attribute.name.end + 2, '{...')
     codes.replaceRange(
       attribute.end - 1,
       attribute.end - 1,
@@ -52,11 +47,11 @@ export function transformOnWithModifiers(
   nodes: JsxDirective[],
   options: TransformOptions,
 ): void {
-  const { codes } = options
+  const { codes, ast, ts } = options
 
   for (const { attribute } of nodes) {
-    const attributeName = getText(attribute.name, options).split('_')[0]
-    const start = getStart(attribute.name, options)
+    const attributeName = attribute.name.getText(ast).split('_')[0]
+    const start = attribute.name.getStart(ast)
     const end = attribute.name.end
 
     codes.replaceRange(start, end, '{...{', [attributeName, start])
@@ -64,12 +59,12 @@ export function transformOnWithModifiers(
     if (!attribute.initializer) {
       codes.replaceRange(end, end, ': () => {}}}')
     } else if (
-      isJsxExpression(attribute.initializer) &&
+      ts.isJsxExpression(attribute.initializer) &&
       attribute.initializer.expression
     ) {
       codes.replaceRange(
         end,
-        getStart(attribute.initializer.expression, options),
+        attribute.initializer.expression.getStart(ast),
         ': ',
       )
 

--- a/packages/volar/src/jsx-ref.ts
+++ b/packages/volar/src/jsx-ref.ts
@@ -22,7 +22,7 @@ function transformRef({
       codes.replaceRange(
         initializer.expression.end,
         initializer.expression.end,
-        `<Parameters<NonNullable<typeof __VLS_ctx_${name.escapedText}['expose']>>[0] | null>`,
+        `<Parameters<NonNullable<typeof __VLS_ctx_${name.text}['expose']>>[0] | null>`,
       )
     }
   }
@@ -40,7 +40,7 @@ function getRefNodes(
       ts.isCallExpression(node) &&
       ts.isIdentifier(node.expression) &&
       !node.typeArguments?.length &&
-      alias.includes(node.expression.escapedText!)
+      alias.includes(node.expression.text!)
     )
   }
 
@@ -56,7 +56,7 @@ function getRefNodes(
           ts.isIdentifier(decl.initializer.expression)
         ) {
           const initializer =
-            decl.initializer.expression.escapedText === '$'
+            decl.initializer.expression.text === '$'
               ? decl.initializer.arguments[0]
               : decl.initializer
           if (isRefCall(initializer))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ catalogs:
     taze:
       specifier: ^19.1.0
       version: 19.1.0
+    ts-macro:
+      specifier: ^0.2.7
+      version: 0.2.7
     tsdown:
       specifier: ^0.12.9
       version: 0.12.9
@@ -1206,8 +1209,8 @@ importers:
         specifier: 'catalog:'
         version: 0.4.1
       ts-macro:
-        specifier: link:/Users/zmj/Documents/tsm/packages/ts-macro
-        version: link:../../../tsm/packages/ts-macro
+        specifier: 'catalog:'
+        version: 0.2.7
     devDependencies:
       '@vue/compiler-dom':
         specifier: 'catalog:'
@@ -7106,6 +7109,9 @@ packages:
     resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
     peerDependencies:
       typescript: '>=4.0.0'
+
+  ts-macro@0.2.7:
+    resolution: {integrity: sha512-rHZfWbnWT6rPYWPAFU4517G9kt8pKXjzaqjNfDFsI7sV8MLxx1RA66uyavplR6c9yEN6WjtD962kGNZOhKL4TA==}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -14680,6 +14686,10 @@ snapshots:
     dependencies:
       picomatch: 4.0.2
       typescript: 5.8.3
+
+  ts-macro@0.2.7:
+    dependencies:
+      muggle-string: 0.4.1
 
   tsconfck@3.1.6(typescript@5.8.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,9 +201,6 @@ catalogs:
     taze:
       specifier: ^19.1.0
       version: 19.1.0
-    ts-macro:
-      specifier: ^0.2.6
-      version: 0.2.6
     tsdown:
       specifier: ^0.12.9
       version: 0.12.9
@@ -1209,8 +1206,8 @@ importers:
         specifier: 'catalog:'
         version: 0.4.1
       ts-macro:
-        specifier: 'catalog:'
-        version: 0.2.6
+        specifier: link:/Users/zmj/Documents/tsm/packages/ts-macro
+        version: link:../../../tsm/packages/ts-macro
     devDependencies:
       '@vue/compiler-dom':
         specifier: 'catalog:'
@@ -7109,9 +7106,6 @@ packages:
     resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
     peerDependencies:
       typescript: '>=4.0.0'
-
-  ts-macro@0.2.6:
-    resolution: {integrity: sha512-hVoeGoJFIat9zsPByds7mIvlD7lqd1R0gaAX23I8zRdM1wRVbvJIaZBFglpRzbAm96mpYP6rQR27g3C21PKeOQ==}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -14686,10 +14680,6 @@ snapshots:
     dependencies:
       picomatch: 4.0.2
       typescript: 5.8.3
-
-  ts-macro@0.2.6:
-    dependencies:
-      muggle-string: 0.4.1
 
   tsconfck@3.1.6(typescript@5.8.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,8 +202,8 @@ catalogs:
       specifier: ^19.1.0
       version: 19.1.0
     ts-macro:
-      specifier: ^0.2.5
-      version: 0.2.5
+      specifier: ^0.2.6
+      version: 0.2.6
     tsdown:
       specifier: ^0.12.9
       version: 0.12.9
@@ -1210,7 +1210,7 @@ importers:
         version: 0.4.1
       ts-macro:
         specifier: 'catalog:'
-        version: 0.2.5
+        version: 0.2.6
     devDependencies:
       '@vue/compiler-dom':
         specifier: 'catalog:'
@@ -7110,8 +7110,8 @@ packages:
     peerDependencies:
       typescript: '>=4.0.0'
 
-  ts-macro@0.2.5:
-    resolution: {integrity: sha512-EVBkHq0RjGdYKE/zzWaAJ6D//WITTX67ocK4JTqgoNAWAjX8Fyl1NkvTXQouvYFyE0rKQ0/6eX2MHcn8AnX2Bg==}
+  ts-macro@0.2.6:
+    resolution: {integrity: sha512-hVoeGoJFIat9zsPByds7mIvlD7lqd1R0gaAX23I8zRdM1wRVbvJIaZBFglpRzbAm96mpYP6rQR27g3C21PKeOQ==}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -14687,7 +14687,7 @@ snapshots:
       picomatch: 4.0.2
       typescript: 5.8.3
 
-  ts-macro@0.2.5:
+  ts-macro@0.2.6:
     dependencies:
       muggle-string: 0.4.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -127,24 +127,3 @@ catalog:
 peerDependencyRules:
   ignoreMissing:
     - search-insights
-catalogs:
-  conflicts_ts-macro_:
-    ts-macro: ''
-  'conflicts_ts-macro_:':
-    ts-macro: ':'
-  conflicts_ts-macro_:catalog:
-    ts-macro: :catalog
-  conflicts_ts-macro_:catalo:
-    ts-macro: :catalo
-  conflicts_ts-macro_:catal:
-    ts-macro: :catal
-  conflicts_ts-macro_:cata:
-    ts-macro: :cata
-  conflicts_ts-macro_:cat:
-    ts-macro: :cat
-  conflicts_ts-macro_:ca:
-    ts-macro: :ca
-  conflicts_ts-macro_:c:
-    ts-macro: :c
-  conflicts_ts-macro_catalog:
-    ts-macro: catalog

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,7 +99,7 @@ catalog:
   rollup-plugin-dts: ^6.2.1
   sirv: ^3.0.1
   taze: ^19.1.0
-  ts-macro: ^0.2.6
+  ts-macro: ^0.2.7
   tsdown: ^0.12.9
   tsx: ^4.20.3
   type-fest: ^4.41.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,7 +99,7 @@ catalog:
   rollup-plugin-dts: ^6.2.1
   sirv: ^3.0.1
   taze: ^19.1.0
-  ts-macro: ^0.2.5
+  ts-macro: ^0.2.6
   tsdown: ^0.12.9
   tsx: ^4.20.3
   type-fest: ^4.41.0
@@ -127,3 +127,24 @@ catalog:
 peerDependencyRules:
   ignoreMissing:
     - search-insights
+catalogs:
+  conflicts_ts-macro_:
+    ts-macro: ''
+  'conflicts_ts-macro_:':
+    ts-macro: ':'
+  conflicts_ts-macro_:catalog:
+    ts-macro: :catalog
+  conflicts_ts-macro_:catalo:
+    ts-macro: :catalo
+  conflicts_ts-macro_:catal:
+    ts-macro: :catal
+  conflicts_ts-macro_:cata:
+    ts-macro: :cata
+  conflicts_ts-macro_:cat:
+    ts-macro: :cat
+  conflicts_ts-macro_:ca:
+    ts-macro: :ca
+  conflicts_ts-macro_:c:
+    ts-macro: :c
+  conflicts_ts-macro_catalog:
+    ts-macro: catalog


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

1. Remove `getStart` and `getEnd` utils, use ts-macro instead.
2. Eliminate the mental burden of not having a related AST util when using vue-tsc. https://github.com/ts-macro/ts-macro/commit/3946bc951d431689632fdb844742ceb8277241ca


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
