### PR TITLE
feat(define-render): auto infer vapor mode

### DIFF
--- a/packages/define-render/src/core/index.ts
+++ b/packages/define-render/src/core/index.ts
@@ -20,6 +20,7 @@ export function transformDefineRender(
   if (!code.includes(DEFINE_RENDER)) return
 
   const lang = getLang(id)
+  const vapor = options?.vapor || new URLSearchParams(id).get('vapor')
   const program = babelParse(code, lang === 'vue' ? 'js' : lang)
 
   const nodes: {
@@ -56,7 +57,7 @@ export function transformDefineRender(
 
     const index = returnStmt ? returnStmt.start! : parent.end! - 1
     const shouldAddFn =
-      !options?.vapor && !isFunctionType(arg) && arg.type !== 'Identifier'
+      !vapor && !isFunctionType(arg) && arg.type !== 'Identifier'
     s.appendLeft(index, `return ${shouldAddFn ? '() => (' : ''}`)
     s.moveNode(arg, index)
     if (shouldAddFn) s.appendRight(index, `)`)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

```vue
<script vapor lang="tsx">
// in vapor component should't wrapped by function.
defineRender(<div>foo</div>)
</script>
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
