### PR TITLE
feat(volar/jsx-directive): support FunctionExpression and ObjectExpression slots

### DIFF
--- a/packages/volar/src/jsx-directive/v-slot.ts
+++ b/packages/volar/src/jsx-directive/v-slot.ts
@@ -163,28 +163,3 @@ export function transformVSlot(
     }
   })
 }
-
-export function transformVSlots(
-  nodes: JsxDirective[],
-  ctxMap: Map<JsxDirective['node'], string>,
-  options: TransformOptions,
-): void {
-  const { codes, ts } = options
-
-  for (const {
-    node,
-    attribute: { initializer },
-  } of nodes) {
-    if (
-      initializer &&
-      ts.isJsxExpression(initializer) &&
-      initializer.expression
-    ) {
-      codes.replaceRange(
-        initializer.expression.end,
-        initializer.expression.end,
-        ` satisfies typeof ${ctxMap.get(node)}.slots`,
-      )
-    }
-  }
-}

--- a/packages/volar/src/jsx-directive/v-slots.ts
+++ b/packages/volar/src/jsx-directive/v-slots.ts
@@ -1,0 +1,42 @@
+import type { JsxDirective, TransformOptions } from '.'
+
+export function transformVSlots(
+  nodes: JsxDirective[],
+  ctxMap: Map<JsxDirective['node'], string>,
+  options: TransformOptions,
+): void {
+  const { codes, ts } = options
+
+  for (const {
+    node,
+    attribute: { initializer },
+  } of nodes) {
+    if (
+      initializer &&
+      ts.isJsxExpression(initializer) &&
+      initializer.expression
+    ) {
+      if (ts.isObjectLiteralExpression(initializer.expression)) {
+        codes.replaceRange(
+          initializer.expression.end,
+          initializer.expression.end,
+          ` satisfies typeof ${ctxMap.get(node)}.slots`,
+        )
+      } else if (
+        ts.isFunctionExpression(initializer.expression) ||
+        ts.isArrowFunction(initializer.expression)
+      ) {
+        codes.replaceRange(
+          initializer.expression.pos,
+          initializer.expression.pos,
+          '(',
+        )
+        codes.replaceRange(
+          initializer.expression.end,
+          initializer.expression.end,
+          `) satisfies typeof ${ctxMap.get(node)}.slots.default`,
+        )
+      }
+    }
+  }
+}

--- a/playground/vue3/src/examples/jsx-directive/v-slot/index.vue
+++ b/playground/vue3/src/examples/jsx-directive/v-slot/index.vue
@@ -45,6 +45,14 @@ defineRender(() => (
 
       <div>default: end</div>
     </Child>
+
+    <Child>
+      {{
+        default: ({ foo }) => <div>{foo}</div>,
+      }}
+    </Child>
+
+    <Child>{({ foo }) => foo}</Child>
   </fieldset>
 ))
 </script>


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

```tsx
<Comp>
  { ({foo}) => <div>{foo}</div> }
</Comp>
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
