### PR TITLE
fix(define-prop): add missing macro type definitions

### DIFF
--- a/packages/define-prop/macros-global.d.ts
+++ b/packages/define-prop/macros-global.d.ts
@@ -1,0 +1,2 @@
+declare const defineProp: typeof import('./macros').defineProp
+declare const $defineProp: typeof import('./macros').$defineProp

--- a/packages/define-prop/macros.d.ts
+++ b/packages/define-prop/macros.d.ts
@@ -1,0 +1,123 @@
+import { TEST_NODE_XML } from "./fixtures/diagrams"
+import {
+    expect,
+    getIframe,
+    getIframeContent,
+    sendMessage,
+    test,
+    waitForComplete,
+} from "./lib/fixtures"
+import { createMockSSEResponse } from "./lib/helpers"
+
+test.describe("Iframe Interaction", () => {
+    test("draw.io iframe loads successfully", async ({ page }) => {
+        await page.goto("/", { waitUntil: "networkidle" })
+
+        const iframe = getIframe(page)
+        await expect(iframe).toBeVisible({ timeout: 30000 })
+
+        // iframe should have loaded draw.io content
+        const frame = getIframeContent(page)
+        await expect(
+            frame
+                .locator(".geMenubarContainer, .geDiagramContainer, canvas")
+                .first(),
+        ).toBeVisible({ timeout: 30000 })
+    })
+
+    test("can interact with draw.io toolbar", async ({ page }) => {
+        await page.goto("/", { waitUntil: "networkidle" })
+        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
+
+        const frame = getIframeContent(page)
+
+        // Draw.io menu items should be accessible
+        await expect(
+            frame
+                .locator('text="Diagram"')
+                .or(frame.locator('[title*="Diagram"]'))
+                .filter({ visible: true })
+                .first(),
+        ).toBeVisible({ timeout: 30000 })
+    })
+
+    test("diagram XML is rendered in iframe after generation", async ({
+        page,
+    }) => {
+        await page.route("**/api/chat", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "text/event-stream",
+                body: createMockSSEResponse(
+                    TEST_NODE_XML,
+                    "Here is your diagram:",
+                ),
+            })
+        })
+
+        await page.goto("/", { waitUntil: "networkidle" })
+        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
+
+        await sendMessage(page, "Create a test node")
+        await waitForComplete(page)
+
+        // Give draw.io time to render
+        await page.waitForTimeout(1000)
+    })
+
+    test("zoom controls work in draw.io", async ({ page }) => {
+        await page.goto("/", { waitUntil: "networkidle" })
+        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
+
+        const frame = getIframeContent(page)
+
+        // draw.io should be loaded and functional - check for diagram container
+        await expect(
+            frame.locator(".geDiagramContainer, canvas").first(),
+        ).toBeVisible({ timeout: 10000 })
+    })
+
+    test("can resize the panel divider", async ({ page }) => {
+        await page.goto("/", { waitUntil: "networkidle" })
+        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
+
+        // Find the resizer/divider between panels
+        const resizer = page.locator(
+            '[role="separator"], [data-panel-resize-handle-id], .resize-handle',
+        )
+
+        if ((await resizer.count()) > 0) {
+            await expect(resizer.first()).toBeVisible()
+
+            const box = await resizer.first().boundingBox()
+            if (box) {
+                await page.mouse.move(
+                    box.x + box.width / 2,
+                    box.y + box.height / 2,
+                )
+                await page.mouse.down()
+                await page.mouse.move(box.x + 50, box.y + box.height / 2)
+                await page.mouse.up()
+            }
+        }
+    })
+
+    test("iframe responds to window resize", async ({ page }) => {
+        await page.goto("/", { waitUntil: "networkidle" })
+        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
+
+        const iframe = getIframe(page)
+        const initialBox = await iframe.boundingBox()
+
+        // Resize window
+        await page.setViewportSize({ width: 800, height: 600 })
+        await page.waitForTimeout(500)
+
+        const newBox = await iframe.boundingBox()
+
+        expect(newBox).toBeDefined()
+        if (initialBox && newBox) {
+            expect(newBox.width).toBeLessThanOrEqual(800)
+        }
+    })
+})

--- a/packages/define-prop/macros.d.ts
+++ b/packages/define-prop/macros.d.ts
@@ -1,123 +1,33 @@
-import { TEST_NODE_XML } from "./fixtures/diagrams"
-import {
-    expect,
-    getIframe,
-    getIframeContent,
-    sendMessage,
-    test,
-    waitForComplete,
-} from "./lib/fixtures"
-import { createMockSSEResponse } from "./lib/helpers"
+/**
+ * Define a reactive prop for the component.
+ *
+ * @param name - The name of the prop (optional, defaults to variable name)
+ * @param definition - The prop definition options (optional)
+ * @returns A reactive reference to the prop value
+ */
+export declare function defineProp<T = any>(
+  name?: string,
+  definition?: {
+    type?: T
+    required?: boolean
+    default?: T | (() => T)
+    validator?: (value: T) => boolean
+  }
+): T
 
-test.describe("Iframe Interaction", () => {
-    test("draw.io iframe loads successfully", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
-
-        const iframe = getIframe(page)
-        await expect(iframe).toBeVisible({ timeout: 30000 })
-
-        // iframe should have loaded draw.io content
-        const frame = getIframeContent(page)
-        await expect(
-            frame
-                .locator(".geMenubarContainer, .geDiagramContainer, canvas")
-                .first(),
-        ).toBeVisible({ timeout: 30000 })
-    })
-
-    test("can interact with draw.io toolbar", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
-        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
-
-        const frame = getIframeContent(page)
-
-        // Draw.io menu items should be accessible
-        await expect(
-            frame
-                .locator('text="Diagram"')
-                .or(frame.locator('[title*="Diagram"]'))
-                .filter({ visible: true })
-                .first(),
-        ).toBeVisible({ timeout: 30000 })
-    })
-
-    test("diagram XML is rendered in iframe after generation", async ({
-        page,
-    }) => {
-        await page.route("**/api/chat", async (route) => {
-            await route.fulfill({
-                status: 200,
-                contentType: "text/event-stream",
-                body: createMockSSEResponse(
-                    TEST_NODE_XML,
-                    "Here is your diagram:",
-                ),
-            })
-        })
-
-        await page.goto("/", { waitUntil: "networkidle" })
-        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
-
-        await sendMessage(page, "Create a test node")
-        await waitForComplete(page)
-
-        // Give draw.io time to render
-        await page.waitForTimeout(1000)
-    })
-
-    test("zoom controls work in draw.io", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
-        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
-
-        const frame = getIframeContent(page)
-
-        // draw.io should be loaded and functional - check for diagram container
-        await expect(
-            frame.locator(".geDiagramContainer, canvas").first(),
-        ).toBeVisible({ timeout: 10000 })
-    })
-
-    test("can resize the panel divider", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
-        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
-
-        // Find the resizer/divider between panels
-        const resizer = page.locator(
-            '[role="separator"], [data-panel-resize-handle-id], .resize-handle',
-        )
-
-        if ((await resizer.count()) > 0) {
-            await expect(resizer.first()).toBeVisible()
-
-            const box = await resizer.first().boundingBox()
-            if (box) {
-                await page.mouse.move(
-                    box.x + box.width / 2,
-                    box.y + box.height / 2,
-                )
-                await page.mouse.down()
-                await page.mouse.move(box.x + 50, box.y + box.height / 2)
-                await page.mouse.up()
-            }
-        }
-    })
-
-    test("iframe responds to window resize", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
-        await getIframe(page).waitFor({ state: "visible", timeout: 30000 })
-
-        const iframe = getIframe(page)
-        const initialBox = await iframe.boundingBox()
-
-        // Resize window
-        await page.setViewportSize({ width: 800, height: 600 })
-        await page.waitForTimeout(500)
-
-        const newBox = await iframe.boundingBox()
-
-        expect(newBox).toBeDefined()
-        if (initialBox && newBox) {
-            expect(newBox.width).toBeLessThanOrEqual(800)
-        }
-    })
-})
+/**
+ * Define a reactive prop with $ syntax for reactive transform.
+ *
+ * @param name - The name of the prop (optional, defaults to variable name)
+ * @param definition - The prop definition options (optional)
+ * @returns A reactive reference to the prop value
+ */
+export declare function $defineProp<T = any>(
+  name?: string,
+  definition?: {
+    type?: T
+    required?: boolean
+    default?: T | (() => T)
+    validator?: (value: T) => boolean
+  }
+): T

--- a/packages/define-prop/macros.d.ts
+++ b/packages/define-prop/macros.d.ts
@@ -1,10 +1,14 @@
 /**
  * Define a reactive prop for the component.
  *
- * @param name - The name of the prop (optional, defaults to variable name)
- * @param definition - The prop definition options (optional)
- * @returns A reactive reference to the prop value
+ * Kevin Edition:
+ *   defineProp(name?, definition?)
+ *
+ * Johnson Edition:
+ *   defineProp(value?, required?, rest?)
  */
+
+/** Kevin Edition: defineProp(name?, definition?) */
 export declare function defineProp<T = any>(
   name?: string,
   definition?: {
@@ -12,16 +16,17 @@ export declare function defineProp<T = any>(
     required?: boolean
     default?: T | (() => T)
     validator?: (value: T) => boolean
-  }
+  },
 ): T
 
-/**
- * Define a reactive prop with $ syntax for reactive transform.
- *
- * @param name - The name of the prop (optional, defaults to variable name)
- * @param definition - The prop definition options (optional)
- * @returns A reactive reference to the prop value
- */
+/** Johnson Edition: defineProp(value?, required?, rest?) */
+export declare function defineProp<T = any>(
+  value?: T,
+  required?: boolean,
+  rest?: Record<string, any>,
+): T
+
+/** Kevin Edition with $ (reactive transform) */
 export declare function $defineProp<T = any>(
   name?: string,
   definition?: {
@@ -29,5 +34,12 @@ export declare function $defineProp<T = any>(
     required?: boolean
     default?: T | (() => T)
     validator?: (value: T) => boolean
-  }
+  },
+): T
+
+/** Johnson Edition with $ (reactive transform) */
+export declare function $defineProp<T = any>(
+  value?: T,
+  required?: boolean,
+  rest?: Record<string, any>,
 ): T

--- a/packages/macros/macros-global.d.ts
+++ b/packages/macros/macros-global.d.ts
@@ -3,6 +3,7 @@
 /// <reference types="unplugin-vue-define-options/macros-global" />
 /// <reference types="@vue-macros/define-props/macros-global" />
 /// <reference types="@vue-macros/define-props-refs/macros-global" />
+/// <reference types="@vue-macros/define-prop/macros-global" />
 /// <reference types="@vue-macros/define-render/macros-global" />
 /// <reference types="@vue-macros/define-slots/macros-global" />
 /// <reference types="@vue-macros/define-stylex/macros-global" />


### PR DESCRIPTION
## Summary

- Add `macros.d.ts` with type definitions for `defineProp` and `$defineProp`
- Add `macros-global.d.ts` with global type declarations
- Add `/// <reference types="@vue-macros/define-prop/macros-global" />` to the main `macros-global.d.ts`

## Problem

`@vue-macros/define-prop` was the only package missing macro type definitions. All other packages (`define-emit`, `define-models`, `define-props`, etc.) have their own `macros.d.ts` and `macros-global.d.ts` files, but `define-prop` did not.

This caused TypeScript to not recognize `defineProp` and `$defineProp` as global macros when using `vue-macros/macros-global.d.ts`.

## Fix

Created the missing type definition files following the same pattern as other packages, and added the reference to the main `macros-global.d.ts`.

Fixes #1011
